### PR TITLE
ci: bump actions + dynamic go version + auto-release + badge fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,11 +13,11 @@ jobs:
     name: ui (build + test + budget)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
           cache-dependency-path: ui/package-lock.json
 
@@ -46,7 +46,7 @@ jobs:
           fi
 
       - name: Upload ui/dist
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ui-dist
           path: ui/dist
@@ -64,18 +64,18 @@ jobs:
     env:
       CGO_ENABLED: "1"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
-          go-version: '1.22'
+          go-version-file: go.mod
 
       - name: Assert C toolchain (macOS)
         if: runner.os == 'macOS'
         run: clang --version
 
       - name: Go build cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cache/go-build
@@ -88,7 +88,7 @@ jobs:
       # Hydrate ui/dist with the build artifact produced by the `ui` job so
       # the //go:embed ui/dist directive has real assets to embed.
       - name: Download ui/dist
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: ui-dist
           path: ui/dist
@@ -103,7 +103,7 @@ jobs:
         run: CGO_ENABLED=1 go build -tags sqlite_fts5 -o docsiq ./
 
       - name: Upload docsiq binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: docsiq-${{ matrix.os }}
           path: docsiq
@@ -115,14 +115,14 @@ jobs:
     needs: ui
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
-          go-version: '1.22'
+          go-version-file: go.mod
 
       - name: cache go build
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cache/go-build
@@ -130,7 +130,7 @@ jobs:
           key: go-integ-${{ hashFiles('go.sum') }}
 
       - name: Download ui/dist
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: ui-dist
           path: ui/dist

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,53 @@
+name: release
+
+# Auto-cuts a beta prerelease on every main push.
+# Tag pushes are ignored so the workflow doesn't recurse.
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-main
+  cancel-in-progress: false
+
+jobs:
+  release:
+    name: auto-tag + release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Compute next beta tag
+        id: ver
+        run: |
+          latest=$(git tag -l 'v0.0.0-beta.*' \
+            | grep -E 'v0\.0\.0-beta\.[0-9]+$' \
+            | sort -V \
+            | tail -1)
+          if [ -z "$latest" ]; then
+            next="v0.0.0-beta.1"
+          else
+            n=${latest##*.}
+            next="v0.0.0-beta.$((n+1))"
+          fi
+          echo "tag=$next" >> "$GITHUB_OUTPUT"
+          echo "Next tag: $next"
+
+      - name: Create tag + release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -eu
+          tag="${{ steps.ver.outputs.tag }}"
+          git tag "$tag"
+          git push origin "$tag"
+          gh release create "$tag" \
+            --target "${{ github.sha }}" \
+            --prerelease \
+            --generate-notes \
+            --title "$tag"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Security Scan](https://github.com/RandomCodeSpace/docsiq/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/RandomCodeSpace/docsiq/actions/workflows/ci.yml)
 [![OpenSSF Score](https://api.scorecard.dev/projects/github.com/RandomCodeSpace/docsiq/badge)](https://scorecard.dev/viewer/?uri=github.com/RandomCodeSpace/docsiq)
-[![Release](https://img.shields.io/github/v/release/RandomCodeSpace/docsiq)](https://github.com/RandomCodeSpace/docsiq/releases)
+[![Release](https://img.shields.io/github/v/release/RandomCodeSpace/docsiq?include_prereleases&sort=semver)](https://github.com/RandomCodeSpace/docsiq/releases)
 [![Go Version](https://img.shields.io/github/go-mod/go-version/RandomCodeSpace/docsiq)](https://github.com/RandomCodeSpace/docsiq/blob/main/go.mod)
 
 docsiq is a GraphRAG-powered knowledge base that runs as a single Go binary.


### PR DESCRIPTION
## Summary

Three CI hygiene items in one PR.

### 1. Action bumps

| Action | Before | After |
|---|---|---|
| actions/checkout | v4 | v6 |
| actions/setup-go | v5 | v6 |
| actions/setup-node | v4 | v6 |
| actions/cache | v4 | v5 |
| actions/upload-artifact | v4 | v7 |
| actions/download-artifact | v4 | v8 |

### 2. Dynamic Go version
\`setup-go\` now reads \`go-version-file: go.mod\` (currently \`go 1.25.0\`) instead of a hard-pinned \`1.22\`. Bumping \`go.mod\` is the single source of truth — no pipeline drift.

Node 20 → 22 LTS (runner warned about deprecation).

### 3. Release automation
- New \`.github/workflows/release.yml\` — every push to \`main\` increments the beta counter and cuts a prerelease with auto-generated notes. Prior releases were cut by hand; 32 betas exist and everything after \`beta.32\` was unreleased.
- README \`Release\` badge gets \`?include_prereleases&sort=semver\` so it tracks the latest beta correctly (bare badge was stuck on \`v0.0.0-beta\` because shields.io looks for stable releases).
- \`v0.0.0-beta.33\` was cut manually off \`main\` while this PR was in flight.

## Test plan
- [ ] CI green on this PR
- [ ] \`ui-dist\` artifact v7 upload → v8 download round-trips cleanly
- [ ] After merge: the release workflow runs and cuts \`v0.0.0-beta.34\`
- [ ] Release badge updates to reflect latest beta

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow infrastructure and action versions to maintain compatibility with the latest development tools and environments

* **New Features**
  * Added automated beta release workflow that automatically generates and publishes new beta releases when code is pushed to the main branch

* **Documentation**
  * Updated project release badge to display prerelease versions alongside stable releases with semantic version sorting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->