### PR TITLE
ci: add OSSF Scorecard workflow

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,45 @@
+name: scorecard
+
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: '0 6 * * 1'
+  push:
+    branches: [main]
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      id-token: write
+      contents: read
+      actions: read
+
+    steps:
+      - name: checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - name: run scorecard
+        uses: ossf/scorecard-action@99c09fe975337306107572b4fdf4db224cf8e2f2 # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: upload artifact
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        with:
+          name: scorecard-results
+          path: results.sarif
+          retention-days: 5
+
+      - name: upload sarif to code scanning
+        uses: github/codeql-action/upload-sarif@865f5f5c36632f18690a3d569fa0a764f2da0c3e # v3
+        with:
+          sarif_file: results.sarif


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/scorecard.yml` running weekly + on push to main
- Publishes results to scorecard.dev, populating the existing OpenSSF Score badge
- Uploads SARIF to Code Scanning for visibility in the Security tab
- All actions pinned by commit SHA per scorecard best practice

## Test plan
- [x] Workflow passes lint (valid YAML, correct permissions)
- [ ] CI checks pass on PR
- [ ] After merge: scorecard runs on main, badge populates within a few minutes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated security analysis workflow that runs OSSF Scorecard checks on the repository, generates security assessment reports, and publishes findings to GitHub Code Scanning for centralized vulnerability tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->