### PR TITLE
fix(ci): use scorecard commit SHA (not tag object)

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -26,7 +26,7 @@ jobs:
           persist-credentials: false
 
       - name: run scorecard
-        uses: ossf/scorecard-action@99c09fe975337306107572b4fdf4db224cf8e2f2 # v2.4.3
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
         with:
           results_file: results.sarif
           results_format: sarif


### PR DESCRIPTION
Previous pin (99c09fe) was the annotated tag object SHA; scorecard.dev rejected it as an imposter commit. Replaced with 4eaacf0 — the actual v2.4.3 commit in ossf/scorecard-action.