### PR TITLE
fix(ci): peel codeql-action v3 to commit SHA

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -40,6 +40,6 @@ jobs:
           retention-days: 5
 
       - name: upload sarif to code scanning
-        uses: github/codeql-action/upload-sarif@865f5f5c36632f18690a3d569fa0a764f2da0c3e # v3
+        uses: github/codeql-action/upload-sarif@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a # v3
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
Same imposter-commit pattern as PR #16 — v3 is an annotated tag, so the tag-ref SHA isn't a commit and scorecard.dev rejects it. Replaced 865f5f5 → ce64ddc.