### PR TITLE
test(vectorindex): skip Recall10k under -race

### DIFF
--- a/internal/vectorindex/hnsw_test.go
+++ b/internal/vectorindex/hnsw_test.go
@@ -215,6 +215,13 @@ func TestHNSW_Recall10k(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping 10k benchmark in -short")
 	}
+	if raceEnabled {
+		// Workload is fully sequential (no goroutines), so the race
+		// detector has nothing to catch here — it just adds ~10× overhead
+		// that dominates CI. Concurrency correctness is covered by
+		// TestHNSW_ConcurrentAddSearch, which DOES run under -race.
+		t.Skip("skipping 10k recall benchmark under -race (sequential workload)")
+	}
 	const (
 		n   = 10_000
 		dim = 384

--- a/internal/vectorindex/race_off.go
+++ b/internal/vectorindex/race_off.go
@@ -1,0 +1,5 @@
+//go:build !race
+
+package vectorindex
+
+const raceEnabled = false

--- a/internal/vectorindex/race_on.go
+++ b/internal/vectorindex/race_on.go
@@ -1,0 +1,10 @@
+//go:build race
+
+package vectorindex
+
+// raceEnabled reports whether the package was compiled with -race.
+// Some long-running deterministic benchmarks (e.g. TestHNSW_Recall10k)
+// gain nothing from the race detector — they're sequential — and pay
+// ~10× overhead that dominates CI time. Those tests skip when this is
+// true, leaving the explicitly concurrent tests to exercise the detector.
+const raceEnabled = true


### PR DESCRIPTION
## Summary
\`TestHNSW_Recall10k\` was the integration-CI bottleneck at ~410s (68% of the 10-min job). Workload is 100% sequential — the race detector has nothing to catch and just adds ~10× overhead.

Fix: standard \`raceEnabled\` build-tagged constant; skip only this test under \`-race\`. \`TestHNSW_ConcurrentAddSearch\` still runs under \`-race\` and covers the actual concurrent path.

## Local timings
| Command | Before | After |
|--|--|--|
| \`go test -run Recall10k\` | n/a | 68s (recall=1.000) |
| \`go test -race -run Recall10k\` | ~410s | **1s (skip)** |
| \`go test -race -run ConcurrentAdd\` | 2s | 2s |

## CI impact
Integration job: ~600s → ~190s (~7 min saved per run).

## Test plan
- [x] Recall10k runs + passes without -race locally
- [x] Recall10k skips cleanly under -race locally
- [x] Concurrent test still runs under -race