### PR TITLE
ci: drop darwin-amd64 from release matrix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,10 +77,6 @@ jobs:
             goos: linux
             goarch: amd64
             suffix: linux-amd64
-          - runner: macos-13
-            goos: darwin
-            goarch: amd64
-            suffix: darwin-amd64
           - runner: macos-latest
             goos: darwin
             goarch: arm64


### PR DESCRIPTION
macos-13 (Intel) runners are scarce — builds queue 5-10+ min, blocking every release. Apple Silicon since 2020; new Mac devs are all arm64. Intel Mac devs can `go install` or build from source.