### PR TITLE
ci: drop push:main trigger from ci and fuzz (saves ~2min/merge)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,6 @@
 name: ci
 
 on:
-  push:
-    branches: [main]
   pull_request:
 
 permissions: read-all

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -4,8 +4,6 @@ name: fuzz (smoke)
 # for continuous fuzzing (OSS-Fuzz Tier 2) — just catches obvious
 # regressions before merge.
 on:
-  push:
-    branches: [main]
   pull_request:
 
 permissions: read-all


### PR DESCRIPTION
## Summary

Drops the redundant \`push: branches: [main]\` trigger from \`ci.yml\` and \`fuzz.yml\`. The PR check on \`pull/N/merge\` already validates the merged-state tree — re-running these workflows on \`main\` after a squash-merge duplicates work that already passed.

\`codeql.yml\` keeps its \`push: main\` trigger because the Security tab's default-branch code-scanning data requires a push-scoped SARIF upload.

## Savings

~2 min of compute per merged PR (ci: ~1.5min, fuzz: ~30s).

## Test plan

- [ ] This PR's CI runs once on \`pull_request:\` — no \`push:main\` run should appear after merge
- [ ] Future PRs still run ci + fuzz
- [ ] CodeQL still runs on both push-to-main and pull_request (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)