### PR TITLE
chore: add CHANGELOG.md + fill missing BestPractices criteria

### DIFF
--- a/.bestpractices.json
+++ b/.bestpractices.json
@@ -11,6 +11,12 @@
   "contribution_requirements_status": "Met",
   "contribution_requirements_justification": "CONTRIBUTING.md documents PR requirements: go test suite passing, go vet clean, CodeQL passing, Conventional Commit style. https://github.com/RandomCodeSpace/docsiq/blob/main/CONTRIBUTING.md",
 
+  "documentation_interface_status": "Met",
+  "documentation_interface_justification": "CLI interface documented in docs/cli-reference.md; REST API documented in docs/rest-api.md; MCP tool catalogue in docs/mcp-tools.md. https://github.com/RandomCodeSpace/docsiq/tree/main/docs",
+
+  "test_continuous_integration_status": "Met",
+  "test_continuous_integration_justification": "CI runs full test suite (unit + integration + fuzz) on every PR and every push to main. https://github.com/RandomCodeSpace/docsiq/blob/main/.github/workflows/ci.yml",
+
   "license_location_status": "Met",
   "license_location_justification": "https://github.com/RandomCodeSpace/docsiq/blob/main/LICENSE",
 

--- a/.bestpractices.json
+++ b/.bestpractices.json
@@ -66,7 +66,7 @@
   "enhancement_responses_justification": "Enhancement requests receive a triage response within 14 days.",
 
   "vulnerability_report_process_status": "Met",
-  "vulnerability_report_process_justification": "Private vulnerability reporting via GitHub's private advisories; documented in SECURITY.md with 72h acknowledgement SLA. https://github.com/RandomCodeSpace/docsiq/blob/main/SECURITY.md",
+  "vulnerability_report_process_justification": "https://github.com/RandomCodeSpace/docsiq/blob/main/SECURITY.md",
 
   "vulnerability_report_private_status": "Met",
   "vulnerability_report_private_justification": "GitHub private vulnerability reporting is enabled on the repo. https://github.com/RandomCodeSpace/docsiq/security/advisories",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,34 @@
+# Changelog
+
+All notable changes to docsiq are published on
+[GitHub Releases](https://github.com/RandomCodeSpace/docsiq/releases)
+with auto-generated summaries grouped by label (security fixes, breaking
+changes, new features, bug fixes, dependencies). Each release is tagged
+with its signed SHA256SUMS and SLSA build provenance.
+
+This file summarises notable releases. The canonical source is the
+Releases page linked above.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- Governance and community files: `CODE_OF_CONDUCT.md`, `GOVERNANCE.md`,
+  `.github/CODEOWNERS`, `.github/release.yml`, `docs/ACCESSIBILITY.md`
+- `.bestpractices.json` to track OpenSSF BestPractices criteria
+
+### Changed
+- `SECURITY.md`: added "Report archive" section documenting GitHub Issues
+  and Security Advisories as the public archive
+
+## [0.0.2] — 2026-04-20
+
+See <https://github.com/RandomCodeSpace/docsiq/releases/tag/v0.0.2>
+
+## [0.0.1] — 2026-04-15
+
+Initial release.
+
+See <https://github.com/RandomCodeSpace/docsiq/releases/tag/v0.0.1>


### PR DESCRIPTION
## Summary

Addresses BestPractices.dev criteria that were missing or flagged as auto-check failures on project 12628.

## Changes

- **`CHANGELOG.md`** (new) — points to GitHub Releases (auto-generated per-release notes via \`.github/release.yml\`) plus a summary log in Keep-a-Changelog format. Fixes the \`release_notes\` **Unmet** auto-check on bestpractices.dev which looks for a CHANGELOG/NEWS file at repo root.

- **\`.bestpractices.json\`** — add two entries that were missing from the prior passing-tier pass:
  - \`documentation_interface\` → Met (docs/cli-reference.md, rest-api.md, mcp-tools.md)
  - \`test_continuous_integration\` → Met (.github/workflows/ci.yml)

## Totals

- Before: 76 Met / 10 N/A / 0 Unknown (86 entries)
- After:  **78 Met / 10 N/A / 0 Unknown (88 entries)**

## Side-effect (no code change)

GitHub repo \"About\" panel also populated via \`gh api\` PATCH:
- Description: \"GraphRAG-powered local documentation search — entity extraction, vector + graph retrieval, MCP server. Written in Go.\"
- Homepage: repo URL
- Topics: graphrag, rag, retrieval-augmented-generation, knowledge-graph, vector-search, mcp-server, documentation-search, go, sqlite, langchaingo

## Form-field reminder

On the bestpractices.dev form, \`vulnerability_report_process\` requires a URL in its dedicated URL field (separate from the justification). Paste:
\`https://github.com/RandomCodeSpace/docsiq/blob/main/SECURITY.md\`

## Test plan

- [ ] CI passes
- [ ] \`.bestpractices.json\` remains valid JSON (verified locally: 78/10/0)
- [ ] CHANGELOG.md renders on GitHub repo root
- [ ] Next BestPractices scan picks up CHANGELOG.md and flips \`release_notes\` to Met

🤖 Generated with [Claude Code](https://claude.com/claude-code)