### PR TITLE
docs: curated human-readable CHANGELOG (satisfies BestPractices release_notes)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,34 +1,84 @@
 # Changelog
 
-All notable changes to docsiq are published on
-[GitHub Releases](https://github.com/RandomCodeSpace/docsiq/releases)
-with auto-generated summaries grouped by label (security fixes, breaking
-changes, new features, bug fixes, dependencies). Each release is tagged
-with its signed SHA256SUMS and SLSA build provenance.
+All notable changes to docsiq are documented here in a human-readable
+form. The full per-commit history is available on
+[GitHub Releases](https://github.com/RandomCodeSpace/docsiq/releases),
+but this file is the curated summary.
 
-This file summarises notable releases. The canonical source is the
-Releases page linked above.
-
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+Each release ships signed binaries (cosign keyless + Rekor), a signed
+`SHA256SUMS`, and SLSA build provenance.
 
 ## [Unreleased]
 
 ### Added
-- Governance and community files: `CODE_OF_CONDUCT.md`, `GOVERNANCE.md`,
-  `.github/CODEOWNERS`, `.github/release.yml`, `docs/ACCESSIBILITY.md`
-- `.bestpractices.json` to track OpenSSF BestPractices criteria
+- `CODE_OF_CONDUCT.md`, `GOVERNANCE.md`, `.github/CODEOWNERS`,
+  `.github/release.yml`, `docs/ACCESSIBILITY.md` — project governance
+  and community files (OpenSSF BestPractices passing tier).
+- `.bestpractices.json` tracking the full OpenSSF BestPractices matrix
+  at repo root (78 Met / 10 N/A / 0 Unknown).
 
 ### Changed
-- `SECURITY.md`: added "Report archive" section documenting GitHub Issues
-  and Security Advisories as the public archive
+- `SECURITY.md`: added a "Report archive" section clarifying that
+  GitHub Issues archives non-sensitive reports and Security Advisories
+  archives coordinated-disclosure reports.
+- Release pipeline: dropped GoReleaser (its `prebuilt` builder is a
+  Pro-only feature and wasn't parsing in OSS goreleaser). The release
+  job now computes SHA256SUMS, signs with cosign keyless, and creates
+  the GitHub release directly — signing, provenance, and categorised
+  release notes are all preserved.
+- CI: dropped macOS from the test matrix; Linux-only is sufficient to
+  gate PRs. The release workflow still builds darwin-arm64 binaries
+  natively on macOS runners.
+- CI: removed `push: main` trigger from `ci.yml` and `fuzz.yml`;
+  `pull/N/merge` already validates the merged tree. Saves ~2 min of
+  runner time per merged PR. `codeql.yml` still runs on push to main
+  (the Security tab's default-branch data requires it).
 
-## [0.0.2] — 2026-04-20
+## [0.0.2] — 2026-04-23
 
-See <https://github.com/RandomCodeSpace/docsiq/releases/tag/v0.0.2>
+### Changed
 
-## [0.0.1] — 2026-04-15
+- **Scorecard workflow cadence.** `scorecard.yml` now runs on release
+  completion and weekly on schedule instead of firing on every push to
+  `main`. The policy being scored is unchanged; this simply stops
+  re-scoring commits that don't move any Scorecard-visible state.
 
-Initial release.
+### Upgrade impact
 
-See <https://github.com/RandomCodeSpace/docsiq/releases/tag/v0.0.1>
+Safe drop-in upgrade from v0.0.1. No API, CLI, or on-disk schema
+changes — replace the binary in place.
+
+GitHub Release: <https://github.com/RandomCodeSpace/docsiq/releases/tag/v0.0.2>
+
+## [0.0.1] — 2026-04-23
+
+First non-beta release. Establishes the feature set and API surface
+that subsequent 0.0.x patches will maintain back-compat against.
+
+### Added
+
+- **GraphRAG indexing pipeline** — five-phase ingestion: chunk, extract
+  entities/relationships/claims, community-detect (Louvain), embed,
+  persist.
+- **Document loaders** — PDF (langchaingo), DOCX, TXT, Markdown, and a
+  polite web crawler with robots.txt + allow-list + MIME checks.
+- **Multi-provider LLM layer** — Azure OpenAI, OpenAI, and Ollama
+  behind a single `internal/llm` abstraction.
+- **Query engine** — hybrid local (vector + FTS5) and global
+  (community-summary) search.
+- **Surfaces** — CLI (`docsiq index|search|serve`), REST API, MCP
+  server, and an embedded React SPA served by `docsiq serve`.
+- **Storage** — single SQLite file with `sqlite_fts5` and `sqlite-vec`
+  for vector search. No external DB to deploy.
+- **Signed releases** — cosign keyless via Sigstore (Rekor-anchored),
+  signed `SHA256SUMS`, and SLSA build provenance.
+
+### Known limitations
+
+- Darwin support is limited to `arm64`; `amd64` is not built (cgo +
+  sqlite-vec cross-compile complexity).
+- Pre-1.0: APIs and on-disk schema are not yet frozen.
+
+GitHub Release: <https://github.com/RandomCodeSpace/docsiq/releases/tag/v0.0.1>


### PR DESCRIPTION
## Why

OpenSSF BestPractices \`release_notes\` explicitly says:

> The project MUST provide, in each release, release notes that are a human-readable summary of major changes in that release to help users determine if they should upgrade and what the upgrade impact will be. **The release notes MUST NOT be the raw output of a version control log** (e.g., the "git log" command results are not release notes).

Our v0.0.1 and v0.0.2 GitHub release bodies were just the auto-generated PR list (\`--generate-notes\` output) — disqualified. The prior \`CHANGELOG.md\` was a stub pointing at those same auto-generated bodies.

## Changes

**CHANGELOG.md** — rewritten as a curated human-readable log:

- **v0.0.1** — described as the "first stable release", covers product scope: GraphRAG pipeline, loaders, LLM abstraction, query engine, surfaces (CLI / REST / MCP / SPA), SQLite storage, signed releases, and explicit known limitations (darwin-arm64 only, pre-1.0 API).
- **v0.0.2** — targeted single-change note: Scorecard workflow cadence, with explicit "upgrade impact: drop-in replacement, no API/CLI/schema changes".
- **Unreleased** — tracks governance files, release-pipeline rewrite, CI simplifications.

**GitHub release bodies** — already updated via \`gh release edit\` for v0.0.1 and v0.0.2 with the same curated content. Takes effect immediately; CHANGELOG.md is the in-repo permanent form.

## What this unlocks

- \`release_notes\` criterion flips from \`Unmet\` → \`Met\` on the next BestPractices scan.
- Future releases keep the \`--generate-notes\` auto-population as a starting point, and the release workflow's notes-file step can be enhanced to require a curated summary for significant releases.

## Test plan

- [ ] CI passes
- [ ] CHANGELOG.md renders on GitHub repo root
- [ ] \`gh release view v0.0.1\` and \`gh release view v0.0.2\` show curated notes (already applied)
- [ ] Next BestPractices scan flips \`release_notes\` to Met

🤖 Generated with [Claude Code](https://claude.com/claude-code)