### PR TITLE
ci(release): derive release notes from CHANGELOG.md (single source of truth)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -159,6 +159,72 @@ jobs:
           pattern: binary-*
           path: downloaded/
 
+      - name: Resolve release notes from CHANGELOG.md
+        id: notes
+        env:
+          TAG: ${{ needs.tag.outputs.tag }}
+        run: |
+          set -eu
+
+          # Extract the block under `## [<heading>]` up to the next `## [` heading.
+          extract_section() {
+            awk -v h="$1" '
+              $0 ~ "^## \\[" h "\\]" { found=1; next }
+              found && /^## \[/           { exit }
+              found                       { print }
+            ' CHANGELOG.md
+          }
+
+          has_content() { printf '%s' "$1" | grep -Eq '[^[:space:]]'; }
+
+          # The tag arrives as vX.Y.Z; CHANGELOG convention is [X.Y.Z] (no v).
+          TAG_STRIPPED="${TAG#v}"
+
+          body=""
+          for candidate in "$TAG" "$TAG_STRIPPED"; do
+            body=$(extract_section "$candidate")
+            if has_content "$body"; then break; fi
+          done
+
+          if ! has_content "$body"; then
+            # Promote [Unreleased] → [TAG_STRIPPED] — YYYY-MM-DD and insert a fresh empty Unreleased.
+            unreleased=$(extract_section 'Unreleased')
+            if ! has_content "$unreleased"; then
+              echo "::error::CHANGELOG.md has neither a '## [${TAG}]' / '## [${TAG_STRIPPED}]' section nor a non-empty '## [Unreleased]' section."
+              echo "::error::Add a '## [${TAG_STRIPPED}] — YYYY-MM-DD' section (or populate Unreleased) before releasing."
+              exit 1
+            fi
+
+            echo "Promoting [Unreleased] → [${TAG_STRIPPED}] in CHANGELOG.md"
+            date_iso=$(date -u +%Y-%m-%d)
+            python3 - <<PY
+          import pathlib
+          p = pathlib.Path('CHANGELOG.md')
+          t = p.read_text()
+          needle = '## [Unreleased]'
+          replacement = f'## [Unreleased]\n\n## [${TAG_STRIPPED}] — ${date_iso}'
+          if needle not in t:
+              raise SystemExit("no '## [Unreleased]' heading in CHANGELOG.md")
+          p.write_text(t.replace(needle, replacement, 1))
+          PY
+
+            git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+            git config user.name  'github-actions[bot]'
+            git add CHANGELOG.md
+            git commit -m "docs: release ${TAG}"
+            git push origin HEAD:main
+
+            body=$(extract_section "$TAG_STRIPPED")
+          fi
+
+          # Emit to GITHUB_OUTPUT (heredoc form for multi-line).
+          {
+            echo 'body<<__RN_EOF__'
+            printf '%s' "$body"
+            echo
+            echo '__RN_EOF__'
+          } >> "$GITHUB_OUTPUT"
+
       - name: Assemble versioned binaries + SHA256SUMS
         env:
           TAG: ${{ needs.tag.outputs.tag }}
@@ -201,19 +267,11 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ needs.tag.outputs.tag }}
+          NOTES_BODY: ${{ steps.notes.outputs.body }}
         run: |
           set -eu
-          # Draft first so we can get the auto-generated body, then edit
-          # the body to append the cosign Verify footer before publishing.
-          gh release create "$TAG" \
-            --title "$TAG" \
-            --generate-notes \
-            --draft \
-            dist/docsiq-* dist/SHA256SUMS dist/SHA256SUMS.sig dist/SHA256SUMS.pem
-
-          body=$(gh release view "$TAG" --json body -q .body)
           {
-            printf '%s\n\n' "$body"
+            printf '%s\n\n' "$NOTES_BODY"
             printf '### Verify\n\n'
             printf 'All artifacts are signed with [cosign](https://github.com/sigstore/cosign) keyless via Sigstore.\n\n'
             printf '```sh\n'
@@ -226,7 +284,10 @@ jobs:
             printf '```\n'
           } > release-notes.md
 
-          gh release edit "$TAG" --notes-file release-notes.md --draft=false
+          gh release create "$TAG" \
+            --title "$TAG" \
+            --notes-file release-notes.md \
+            dist/docsiq-* dist/SHA256SUMS dist/SHA256SUMS.sig dist/SHA256SUMS.pem
 
       - name: Generate SLSA build provenance
         id: attest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Each release ships signed binaries (cosign keyless + Rekor), a signed
 `SHA256SUMS`, and SLSA build provenance.
 
+> **Contributors:** add bullets under `## [Unreleased]` as part of any
+> PR worth mentioning in release notes. When the release workflow runs,
+> it promotes `[Unreleased]` → `[vX.Y.Z] — YYYY-MM-DD` automatically and
+> uses that section as the GitHub release body. If no non-empty
+> `[Unreleased]` section exists at release time, the workflow fails.
+
 ## [Unreleased]
 
 ### Added


### PR DESCRIPTION
## Summary

Wires CHANGELOG.md into the release workflow as the **single source of truth** for release notes. Replaces \`--generate-notes\` (raw PR list — disqualified by OpenSSF BestPractices \`release_notes\`) with curated content extracted from the CHANGELOG.

## Contributor workflow

1. As part of any PR worth mentioning in release notes, add a bullet under \`## [Unreleased]\` in \`CHANGELOG.md\`.
2. When releasing:
   - Fire \`release.yml\` via \`workflow_dispatch\` with a bump (patch/minor/major).
   - The workflow auto-promotes \`[Unreleased]\` → \`[X.Y.Z] — YYYY-MM-DD\`, inserts a fresh \`[Unreleased]\` above it, commits the rename to main as \`github-actions[bot]\`.
   - The extracted section becomes the GitHub release body.
3. If \`[Unreleased]\` is empty when you fire the workflow, the release **fails** with a clear instruction. No silent \`--generate-notes\` fallback — you curate or you don't release.

## Implementation

**New step: \`Resolve release notes from CHANGELOG.md\`** (runs after \`download-artifact\`):

- awk-extracts the block under \`## [<heading>]\` up to the next \`## [\` heading.
- Tries \`## [vX.Y.Z]\` then \`## [X.Y.Z]\` (the file convention is no-\`v\`; Keep-a-Changelog style).
- If the tag's section is absent, promotes \`[Unreleased]\` via a tiny inline Python edit and pushes the rename commit to main.
- Fails fast if neither the target section nor a non-empty \`[Unreleased]\` exists.
- Emits the extracted section as a multi-line step output.

**Modified step: \`Create GitHub release\`** — now writes \`release-notes.md\` from the extracted body + the existing cosign Verify footer, and passes it via \`--notes-file\`. Removes the draft-then-edit dance.

**CHANGELOG.md** — adds a contributor note at the top explaining the promotion flow so it's discoverable without reading release.yml.

## Consequences

- ✅ \`release_notes\` BestPractices criterion stays Met across every future release — by construction.
- ✅ CHANGELOG.md on main always reflects what was released.
- ⚠️ The binary's embedded \`Commit\` SHA is the pre-rename commit (\`github.sha\` captured during the build job), while the tag points to the post-rename commit. The binary bytes are unaffected. Acceptable mismatch — CHANGELOG.md is doc, not code.

## Test plan

- [ ] Merge this PR
- [ ] Verify \`## [Unreleased]\` has non-empty bullets on main (already does — from PR #46/#48/#49/#50)
- [ ] Delete stale \`v0.0.3\` tag: \`git push origin --delete v0.0.3\`
- [ ] Fire: \`gh workflow run release.yml --ref main -f bump=patch\`
- [ ] Confirm CHANGELOG.md on main got a fresh rename commit
- [ ] Confirm \`v0.0.3\` release body on GitHub contains the curated section + cosign footer (NOT the auto PR list)
- [ ] Confirm \`cosign verify-blob\` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)