### PR TITLE
docs: add OpenSSF Best Practices badge + point release_notes at CHANGELOG.md

### DIFF
--- a/.bestpractices.json
+++ b/.bestpractices.json
@@ -51,7 +51,7 @@
   "version_tags_justification": "https://github.com/RandomCodeSpace/docsiq/tags",
 
   "release_notes_status": "Met",
-  "release_notes_justification": "Generated per release via GitHub's generate_release_notes. https://github.com/RandomCodeSpace/docsiq/releases",
+  "release_notes_justification": "https://github.com/RandomCodeSpace/docsiq/blob/main/CHANGELOG.md",
 
   "report_process_status": "Met",
   "report_process_justification": "https://github.com/RandomCodeSpace/docsiq/blob/main/SECURITY.md",

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # docsiq
 
 [![Security Scan](https://github.com/RandomCodeSpace/docsiq/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/RandomCodeSpace/docsiq/actions/workflows/ci.yml)
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/12628/badge)](https://www.bestpractices.dev/projects/12628)
 [![OpenSSF Score](https://api.scorecard.dev/projects/github.com/RandomCodeSpace/docsiq/badge)](https://scorecard.dev/viewer/?uri=github.com/RandomCodeSpace/docsiq)
 [![Release](https://img.shields.io/github/v/release/RandomCodeSpace/docsiq?include_prereleases&sort=semver)](https://github.com/RandomCodeSpace/docsiq/releases)
 [![Go Version](https://img.shields.io/github/go-mod/go-version/RandomCodeSpace/docsiq)](https://github.com/RandomCodeSpace/docsiq/blob/main/go.mod)


### PR DESCRIPTION
## Changes

- **README.md** — add OpenSSF Best Practices badge (project 12628) next to the existing Security Scan + OpenSSF Score badges.
- **.bestpractices.json** — \`release_notes_justification\` now points at \`CHANGELOG.md\` (the single source of truth after PR #51 + #52), not the raw-PR-list GitHub releases page.

## Why

Badge display is the canonical BestPractices UX. The justification change reflects our new release process — CHANGELOG.md is the curated form, GitHub releases are derived from it.

## Test plan

- [ ] README renders the badge
- [ ] \`.bestpractices.json\` remains valid (verified locally: 78 Met / 10 N/A / 0 Unknown)

🤖 Generated with [Claude Code](https://claude.com/claude-code)