### PR TITLE
fix(security): close CodeQL #33 go/command-injection in runGit (Critical)

### DIFF
--- a/internal/notes/history.go
+++ b/internal/notes/history.go
@@ -100,8 +100,51 @@ func initRepo(notesDir string) error {
 	return nil
 }
 
+// allowedGitSubcommands is the closed set of git subcommands runGit
+// will invoke. This keeps future callers from accidentally passing a
+// user-controlled string in the subcommand slot, and gives CodeQL a
+// recognizable allow-list sanitizer for the go/command-injection rule.
+var allowedGitSubcommands = map[string]bool{
+	"init":   true,
+	"config": true,
+	"add":    true,
+	"log":    true,
+}
+
 // runGit invokes `git -C <notesDir> <args>` and returns combined output.
+//
+// Security:
+//   - No shell — exec.Command takes argv directly.
+//   - notesDir must be non-empty and must not begin with "-" (which
+//     would let it be parsed as a git top-level flag).
+//   - args[0] must be in allowedGitSubcommands.
+//   - Any arg that follows a literal "--" separator must satisfy
+//     filepath.IsLocal — it's expected to be an in-tree relative path.
+//
+// runGit deliberately does NOT handle `commit`. Commit messages come
+// from user input; they're routed through gitCommit which pipes the
+// message via stdin so it never touches argv (see gitCommit below).
 func runGit(notesDir string, args ...string) (string, error) {
+	if notesDir == "" || strings.HasPrefix(notesDir, "-") {
+		return "", fmt.Errorf("runGit: invalid notesDir")
+	}
+	if len(args) == 0 {
+		return "", fmt.Errorf("runGit: no subcommand")
+	}
+	if !allowedGitSubcommands[args[0]] {
+		return "", fmt.Errorf("runGit: disallowed subcommand %q", args[0])
+	}
+	seenDDash := false
+	for _, a := range args[1:] {
+		if a == "--" {
+			seenDDash = true
+			continue
+		}
+		if seenDDash && !filepath.IsLocal(a) {
+			return "", fmt.Errorf("runGit: non-local path arg %q", a)
+		}
+	}
+
 	full := append([]string{"-C", notesDir}, args...)
 	cmd := exec.Command("git", full...)
 	// Detach from any inherited GIT_* env — the caller's config must
@@ -110,6 +153,28 @@ func runGit(notesDir string, args ...string) (string, error) {
 		"GIT_CONFIG_GLOBAL=/dev/null",
 		"GIT_CONFIG_SYSTEM=/dev/null",
 	)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	err := cmd.Run()
+	return buf.String(), err
+}
+
+// gitCommit runs `git commit` reading the message from stdin. The
+// message is never passed as a command-line argument, removing the
+// only path by which user-controlled bytes could have reached the git
+// argv. `--no-gpg-sign` keeps the commit unsigned (we rely on cosign
+// for release signing, not per-commit GPG).
+func gitCommit(notesDir, msg string) (string, error) {
+	if notesDir == "" || strings.HasPrefix(notesDir, "-") {
+		return "", fmt.Errorf("gitCommit: invalid notesDir")
+	}
+	cmd := exec.Command("git", "-C", notesDir, "commit", "--no-gpg-sign", "--allow-empty-message", "-F", "-")
+	cmd.Env = append(os.Environ(),
+		"GIT_CONFIG_GLOBAL=/dev/null",
+		"GIT_CONFIG_SYSTEM=/dev/null",
+	)
+	cmd.Stdin = strings.NewReader(msg)
 	var buf bytes.Buffer
 	cmd.Stdout = &buf
 	cmd.Stderr = &buf
@@ -216,10 +281,7 @@ func autoCommit(notesDir, key, author, subject string, deleted bool) {
 	// which is the desired behavior. `git commit` exits non-zero on
 	// "nothing to commit" — treat that as a silent no-op rather than
 	// a warning.
-	if out, err := runGit(notesDir, "commit",
-		"--no-gpg-sign",
-		"-m", msg,
-	); err != nil {
+	if out, err := gitCommit(notesDir, msg); err != nil {
 		if strings.Contains(out, "nothing to commit") ||
 			strings.Contains(out, "no changes added") {
 			return


### PR DESCRIPTION
## Alert

CodeQL alert **#33** — \`go/command-injection\` — **Critical** severity, \`internal/notes/history.go:106\`.

> Building a system command from user-controlled sources is vulnerable to insertion of malicious code by the user.

\`exec.Command("git", ...)\` in \`runGit\` received user-controlled strings: commit message bytes (author + subject), and relative paths derived from note keys. While \`exec.Command\` uses argv (no shell) which disables the classic shell-injection vector, git itself has flag-based attack surface that CodeQL is right to flag:

- \`--upload-pack=<cmd>\` / \`--receive-pack=<cmd>\` on fetch/push subcommands
- \`-c core.sshCommand=<cmd>\` on any subcommand
- \`-c core.pager=<cmd> log\`
- notesDir beginning with \`-\` would be re-parsed as a top-level flag

## Fix — defense in depth

**1. \`runGit\` gains a strict sanitiser pass:**

- \`notesDir\` must be non-empty and must not start with \`-\`.
- \`args[0]\` must be in a closed allow-list: \`init\`, \`config\`, \`add\`, \`log\`. Any other subcommand is rejected.
- Any arg after a literal \`--\` must satisfy \`filepath.IsLocal\` (same sanitiser introduced in #44 for path-injection).

**2. \`commit\` is deliberately removed from the allow-list.** Commit messages come from user input; routing them through argv was the last remaining taint flow. A new \`gitCommit(notesDir, msg)\` helper runs:

\`\`\`
git -C <notesDir> commit --no-gpg-sign --allow-empty-message -F -
\`\`\`

and **pipes the message via stdin**. User bytes never appear in argv.

**3. \`autoCommit\` switched** from \`runGit(..., "commit", "-m", msg)\` to \`gitCommit(notesDir, msg)\`.

## Why this clears the alert

CodeQL's taint-tracking for \`go/command-injection\`:
- Recognises \`filepath.IsLocal\` as a sanitiser (already proven in alert history after #44).
- Recognises allow-list map membership as a sanitiser for the subcommand position.
- For \`gitCommit\`: user data flows to \`cmd.Stdin\`, not \`cmd.Args\` — no taint into the sink.

## Test results

Local:  \`104/104 tests passing in internal/notes/\`, \`go vet\` clean.

## Files changed

- \`internal/notes/history.go\` (+66 / −4)

## Not addressed

**Alert #11 — SAST score 9/10 (27/30 commits scanned).** Cosmetic Scorecard warning. CodeQL runs on PR + push-to-main + weekly schedule — intermediate feature-branch commits aren't individually scanned. Fixing to 30/30 would require running CodeQL on every push to every branch, which is expensive for a pre-1.0 single-maintainer project. Leaving as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)