### PR TITLE
ci: bump UI bundle budget 580 KiB → 640 KiB

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,15 +32,15 @@ jobs:
       - name: Build UI
         run: npm --prefix ui run build
 
-      - name: Assert bundle budget (≤ 580 KB JS + CSS, initial chunk)
+      - name: Assert bundle budget (≤ 640 KiB JS + CSS, initial chunk)
         run: |
           set -eu
           js_bytes=$(stat -c %s ui/dist/assets/index-*.js 2>/dev/null || stat -f %z ui/dist/assets/index-*.js)
           css_bytes=$(stat -c %s ui/dist/assets/index-*.css 2>/dev/null || stat -f %z ui/dist/assets/index-*.css)
           total=$((js_bytes + css_bytes))
           echo "bundle: ${js_bytes} js + ${css_bytes} css = ${total} bytes"
-          if [ "$total" -gt 593920 ]; then
-            echo "::error::Bundle ${total} B exceeds 580 KB budget"
+          if [ "$total" -gt 655360 ]; then
+            echo "::error::Bundle ${total} B exceeds 640 KiB budget"
             exit 1
           fi
 


### PR DESCRIPTION
## Summary
- Bundle on main (~583 KiB initial JS+CSS) exceeds the 580 KiB gate
- Growth came from already-merged UI redesign waves (shadcn sidebar, command palette, docs/graph)
- Raise to 640 KiB (655,360 B) for ~55 KiB headroom

## Why this is safe
- No source code changes
- Budget is a ceiling, not a target — build output is unchanged
- Unblocks open Dependabot PRs (#21, #23, #25, #35) that share the same CI gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)