### PR TITLE
fix(ci): exclude screenshots.spec.ts from default playwright run

### DIFF
--- a/ui/playwright.config.ts
+++ b/ui/playwright.config.ts
@@ -6,6 +6,11 @@ const isCI = !!process.env.CI;
 
 export default defineConfig({
   testDir: "./e2e",
+  // Screenshot regeneration is a manual task run against a live docsiq
+  // backend with seeded fixtures; it has no role in the CI smoke suite
+  // and fails fast when no backend is reachable. Gate behind the
+  // PLAYWRIGHT_SCREENSHOTS env var so the dedicated script opts in.
+  testIgnore: process.env.PLAYWRIGHT_SCREENSHOTS ? undefined : ["**/screenshots.spec.ts"],
   fullyParallel: true,
   forbidOnly: isCI,
   retries: isCI ? 1 : 0,


### PR DESCRIPTION
## Summary

Block 7's `ui/e2e/screenshots.spec.ts` (merged in #69) talks to a live docsiq backend on a fixed port. CI only boots the Vite dev server, so every screenshot test fails with ERR_CONNECTION_REFUSED. This caused PR #71 (Block 5) to show a red \`e2e (chromium)\` check; it ended up merging because that workflow isn't a required check, but every future UI-touching PR inherits the same red signal.

Gate the spec behind a `PLAYWRIGHT_SCREENSHOTS` env var so the dedicated regeneration script opts in and the default e2e suite ignores it.

## Test plan

- [ ] CI \`e2e (chromium)\` job on this PR passes (screenshots spec skipped)
- [ ] \`PLAYWRIGHT_SCREENSHOTS=1 playwright test\` still runs screenshots manually

🤖 Generated with [Claude Code](https://claude.com/claude-code)