### PR TITLE
fix(ui): pin NODE_ENV=test in vitest config (RAN-40)

### DIFF
--- a/ui/vitest.config.ts
+++ b/ui/vitest.config.ts
@@ -2,6 +2,12 @@ import { defineConfig } from "vitest/config";
 import react from "@vitejs/plugin-react";
 import { resolve } from "path";
 
+// React 19's CJS entry picks production vs development at require-time off
+// NODE_ENV; the production build omits `act`. Force the test build before any
+// worker forks so callers with NODE_ENV=production (CI-adjacent shells, the
+// Paperclip agent harness) get the same result as bare `npm test`.
+process.env.NODE_ENV = "test";
+
 export default defineConfig({
   plugins: [react()],
   resolve: {


### PR DESCRIPTION
## Summary

- React 19's CJS entry picks production vs development at require-time off `process.env.NODE_ENV`; the production build omits `act`, which `@testing-library/react` needs. Shells that export `NODE_ENV=production` (CI-adjacent shells, the Paperclip agent harness) silently fail 78/97 tests with `TypeError: React.act is not a function`. CI runners (NODE_ENV unset) are unaffected.
- Vitest's own `process.env.NODE_ENV ||= 'test'` only fires when NODE_ENV is unset, and `--mode test` does not override an already-set NODE_ENV in vitest 4. Forcing `process.env.NODE_ENV = 'test'` at the top of `vitest.config.ts` (before any worker forks) makes the suite deterministic regardless of caller env. No new dependencies.

## Test plan

- [x] `NODE_ENV=production npm --prefix ui run test` → 97/97 pass
- [x] `NODE_ENV=production npm --prefix ui run test:coverage` → 97/97 pass, coverage report generated
- [x] `NODE_ENV=test npm --prefix ui run test` → 97/97 pass
- [x] `NODE_ENV` unset, `npm --prefix ui run test` → 97/97 pass (CI parity)
- [ ] CI `ui (build + test + budget)` job stays green

Closes RAN-40.