### PR TITLE
docs(changelog): per-version keep-a-changelog entries (RAN-61)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,19 +1,15 @@
 # Changelog
 
-Curated release notes for each version are published on
-**[GitHub Releases](https://github.com/RandomCodeSpace/docsiq/releases)**.
+All notable changes to **docsiq** are documented in this file.
 
-Every release includes:
+The format is based on [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.html).
+Each release is identified by an immutable `vX.Y.Z` git tag.
 
-- A human-readable summary of changes (the release body).
-- A `CHANGELOG.md` asset attached to the release, containing the same
-  curated notes.
-- Signed binaries (cosign keyless + Rekor), a signed `SHA256SUMS`, and
-  SLSA build provenance.
+## How releases are produced
 
-## Release procedure
-
-Release notes are provided at release time, not maintained in-repo:
+Releases are cut by the manual
+[`release.yml`](.github/workflows/release.yml) workflow:
 
 ```sh
 gh workflow run release.yml --ref main \
@@ -21,10 +17,123 @@ gh workflow run release.yml --ref main \
   -f notes=$'### Changed\n\n- Describe major changes...\n\n### Upgrade impact\n\nDrop-in replacement — no schema/API changes.'
 ```
 
-The workflow uses the `notes` input verbatim as the release body and
-also uploads it as `CHANGELOG.md` on the release page. The repository
-never auto-commits a CHANGELOG entry — this file is static.
+The workflow uses the `notes` input verbatim as the GitHub Release body
+and uploads it as `CHANGELOG.md` on the release page. Each release ships
+signed binaries (cosign keyless via Sigstore + Rekor anchoring), a signed
+`SHA256SUMS`, and SLSA build provenance.
 
-The project follows
-[Semantic Versioning](https://semver.org/spec/v2.0.0.html) and each
-release is identified by its immutable `vX.Y.Z` tag.
+This in-repo file is the canonical, human-curated history. The matching
+GitHub Release page for each `vX.Y.Z` tag carries the same notes plus the
+signed artifacts and verification snippet.
+
+## [Unreleased]
+
+No unreleased changes.
+
+## [0.0.3] — 2026-04-23
+
+Supply-chain hardening: complete OpenSSF Best Practices passing tier and
+flip the published Scorecard signal up.
+
+### Added
+- `.bestpractices.json` so the OpenSSF Best Practices badge tracks
+  project [12628](https://www.bestpractices.dev/en/projects/12628)
+  automatically. ([#45])
+- Governance and community files (`SECURITY.md`, `CODE_OF_CONDUCT.md`,
+  `CONTRIBUTING.md`, issue / PR templates) to flip the remaining
+  Best Practices criteria to Met. ([#46])
+- Initial `CHANGELOG.md` and the rest of the missing Best Practices
+  criteria (release-notes pointer, vulnerability-report instructions,
+  build documentation pointers). ([#48])
+
+### Changed
+- Release signing path: switched to `goreleaser` to expose a
+  `Packaging` signal to OSSF Scorecard, then dropped it again because
+  prebuilt-binary signing is a goreleaser Pro feature. The current
+  release path is inline `cosign sign-blob` + `gh release create`,
+  preserving keyless signing without the Pro dependency.
+  ([#43], [#50])
+- CI hygiene: dropped `push: main` triggers from the `ci` and `fuzz`
+  workflows. Both still run on PRs and on the relevant scheduled jobs;
+  this removes ~2 minutes from each merge while keeping branch
+  protection coverage intact. ([#47])
+
+### Fixed
+- CodeQL path/command-injection findings closed by adding
+  `filepath.IsLocal` sanitisers on user-supplied path inputs in the
+  loader and crawler boundaries. ([#44])
+- `TestScale_1000Notes` flake on macOS — dropped macOS from the test
+  matrix (Linux-only CI is sufficient for the supported targets;
+  darwin-arm64 builds are still produced in the release matrix).
+  ([#49])
+
+[#43]: https://github.com/RandomCodeSpace/docsiq/pull/43
+[#44]: https://github.com/RandomCodeSpace/docsiq/pull/44
+[#45]: https://github.com/RandomCodeSpace/docsiq/pull/45
+[#46]: https://github.com/RandomCodeSpace/docsiq/pull/46
+[#47]: https://github.com/RandomCodeSpace/docsiq/pull/47
+[#48]: https://github.com/RandomCodeSpace/docsiq/pull/48
+[#49]: https://github.com/RandomCodeSpace/docsiq/pull/49
+[#50]: https://github.com/RandomCodeSpace/docsiq/pull/50
+
+## [0.0.2] — 2026-04-23
+
+Small CI-only follow-up to v0.0.1. No user-facing behaviour changes.
+
+### Changed
+- OpenSSF Scorecard workflow cadence: `scorecard.yml` now runs on
+  release completion and on a weekly schedule, instead of firing on
+  every push to `main`. The policy being scored is unchanged; this
+  trims noise from re-scoring commits that don't move any
+  scorecard-visible state. ([#42])
+
+### Upgrade impact
+Safe drop-in upgrade from v0.0.1. No API, CLI, or on-disk schema
+changes — replace the binary in place.
+
+[#42]: https://github.com/RandomCodeSpace/docsiq/pull/42
+
+## [0.0.1] — 2026-04-23
+
+First non-beta release of docsiq after an extended beta phase. This
+release establishes the feature set and API surface that subsequent
+0.0.x patches maintain back-compat against.
+
+### Added
+- **GraphRAG indexing pipeline** — five-phase ingestion: chunk →
+  extract entities + relationships + claims → community-detect
+  (Louvain) → embed → persist.
+- **Document loaders** — PDF (langchaingo), DOCX, TXT, Markdown, and a
+  polite web crawler with `robots.txt` + allow-list + MIME checks.
+- **Multi-provider LLM layer** — Azure OpenAI, OpenAI, and Ollama
+  behind a single `internal/llm` abstraction (langchaingo
+  underneath).
+- **Hybrid query engine** — local search (vector + FTS5) plus global
+  search (community-summary).
+- **Surfaces** — CLI (`docsiq index|search|serve`), REST API, MCP
+  server, and an embedded React SPA served by `docsiq serve`.
+- **Storage** — single SQLite file with `sqlite_fts5` + `sqlite-vec`
+  for vector search. No external DB to deploy.
+
+### Security
+- Release binaries signed with [cosign](https://github.com/sigstore/cosign)
+  keyless via Sigstore and anchored to the Rekor transparency log.
+- Signed `SHA256SUMS` published with each release, with verification
+  instructions attached.
+- SLSA build provenance (`.intoto.jsonl`) accompanies the binaries.
+
+### Known limitations
+- Darwin support is limited to `arm64`; `amd64` binaries are not
+  built (cgo + sqlite-vec cross-compile complexity).
+- Pre-1.0: APIs and on-disk schema are not yet frozen.
+
+### Upgrade impact
+No previous stable release exists — this is v0.0.1. Users upgrading
+from `v0.0.0-beta.*` should start with a fresh data directory; the
+schema is the same as the final beta but the beta tags have been
+retired.
+
+[Unreleased]: https://github.com/RandomCodeSpace/docsiq/compare/v0.0.3...HEAD
+[0.0.3]: https://github.com/RandomCodeSpace/docsiq/releases/tag/v0.0.3
+[0.0.2]: https://github.com/RandomCodeSpace/docsiq/releases/tag/v0.0.2
+[0.0.1]: https://github.com/RandomCodeSpace/docsiq/releases/tag/v0.0.1


### PR DESCRIPTION
## Summary

Replaces the meta-pointer `CHANGELOG.md` with [keep-a-changelog 1.1.0](https://keepachangelog.com/en/1.1.0/) format plus per-version sections for `v0.0.1`, `v0.0.2`, and `v0.0.3`.

The bestpractices.dev autofill scans for per-version headers and skips meta files, so the previous file kept `release_notes_status` stuck at `Unmet — No release notes file found` and held project [12628](https://www.bestpractices.dev/en/projects/12628) at 42/43 MUST. With per-version headers in place, a board-side re-trigger of the autofill should flip the criterion to Met (target: 43/43 MUST).

## What changed

- Rewrote `CHANGELOG.md` with keep-a-changelog headers (`## [0.0.3] — 2026-04-23`, etc.).
- Each version section uses keep-a-changelog category headings (`### Added`, `### Changed`, `### Fixed`, `### Security`, `### Upgrade impact`, `### Known limitations`) sourced from the existing GitHub Release bodies.
- Top-of-file documents the format, SemVer adherence, and the existing `release.yml` workflow so future releases keep entries in sync.
- Cross-links each version to its tag and PRs.

## Out of scope (per RAN-61 description)

- Back-filling `gh release` notes — `release.yml` is `workflow_dispatch`-only with `notes` as a required input; rewriting historic releases is a separate ask.
- Auto-writing CHANGELOG entries from `release.yml` on release — track separately if desired.

## Test plan

- [x] File lints as valid markdown (rendered locally).
- [ ] After merge, board re-triggers autofill at https://www.bestpractices.dev/en/projects/12628?as=edit and confirms `release_notes_status` flips to Met (43/43 MUST).

Closes RAN-61.

🤖 Generated with [Claude Code](https://claude.com/claude-code)