### PR TITLE
docs(readme): call out C toolchain prerequisite for source builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,14 @@ embed or extract) return `503 {"code": "llm_disabled"}`.
 
 ## Build from source
 
+**Prerequisites:** Go ≥ 1.25, Node ≥ 22, and a working C toolchain
+(`build-essential` on Debian/Ubuntu, `xcode-select --install` on macOS,
+MinGW-w64 / MSYS2 on Windows). Without `gcc` on `PATH`, CGO is silently
+disabled and the build fails at the call site with a misleading
+`undefined: sqlitevec.LoadInto` rather than a clear toolchain error,
+because `internal/sqlitevec/load.go` is gated by `//go:build cgo`. Full
+list: [`docs/getting-started.md`](docs/getting-started.md#prerequisites).
+
 ```bash
 # First time on a connected machine
 npm --prefix ui ci                          # install UI deps


### PR DESCRIPTION
## Summary

- Add a Prerequisites paragraph to the README "Build from source" section.
- Names the misleading symptom (`undefined: sqlitevec.LoadInto`) so anyone hitting it via search lands on the fix.
- Points at the existing comprehensive prerequisites list in `docs/getting-started.md`.

## Why

`internal/sqlitevec/load.go` is gated by `//go:build cgo`. Without `gcc` on `PATH`, CGO is silently disabled and the build fails at the call site (`cmd/serve.go:102`) with `undefined: sqlitevec.LoadInto` instead of a clear toolchain error. Hit this in practice today on a fresh box.

## Test plan

- [x] `git diff` is README-only, additive
- [ ] CI green
- [ ] Reviewer eyeballs the wording