### PR TITLE
fix(config): bind all defaulted keys to env vars; doc GOFLAGS=-tags=sqlite_fts5 for go install

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -24,8 +24,14 @@ project indexed and the MCP endpoint answering queries.
 ## Install
 
 ```bash
-go install github.com/RandomCodeSpace/docsiq@latest
+GOFLAGS='-tags=sqlite_fts5' go install github.com/RandomCodeSpace/docsiq@latest
 ```
+
+The `sqlite_fts5` build tag is required — docsiq uses SQLite's FTS5
+full-text-search extension. Without it the binary fails at runtime with
+`no such module: fts5` when opening a project store. `go install` does
+**not** pick up Makefile tags, so the flag has to come from `GOFLAGS`
+(or `-tags`) on the install command itself.
 
 This drops a `docsiq` binary into `$(go env GOPATH)/bin`. Make sure
 that path is on your `PATH`.
@@ -35,7 +41,7 @@ Alternatively, build from a checkout:
 ```bash
 git clone https://github.com/RandomCodeSpace/docsiq.git
 cd docsiq
-CGO_ENABLED=1 go build -o docsiq .
+CGO_ENABLED=1 go build -tags sqlite_fts5 -o docsiq .
 ```
 
 ## First project

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -273,6 +273,17 @@ func Load(cfgFile string) (*Config, error) {
 	v.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
 	v.AutomaticEnv()
 
+	// Bind every defaulted key to its DOCSIQ_<UPPER_KEY> env variant so
+	// v.Unmarshal honours overrides without requiring a config file.
+	// Without this, only keys explicitly listed via BindEnv are read
+	// from env when nothing in the config tree already mentions them
+	// (Viper #761). The explicit BindEnv calls below stay because they
+	// document the secondary DOCSIQ_API_KEY alias for server.api_key
+	// and harmlessly double-bind the rest.
+	for _, key := range v.AllKeys() {
+		_ = v.BindEnv(key)
+	}
+
 	// Explicit alias: DOCSIQ_API_KEY is a convenience shortcut for
 	// DOCSIQ_SERVER_API_KEY (the auth-middleware API key). Bind both so
 	// either form populates server.api_key. BindEnv names are matched

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -719,3 +719,45 @@ func TestLoad_LogFormatFromEnv(t *testing.T) {
 		t.Errorf("env Log.Format=%q want json", cfg.Log.Format)
 	}
 }
+
+// TestLoad_EnvOverridesLLM is the regression test for the bug where
+// DOCSIQ_LLM_* env vars were silently ignored without a config file
+// because only a handful of keys were explicitly bound via BindEnv
+// (Viper #761). After the fix, every defaulted key — including the
+// nested LLM provider keys — must be reachable via env.
+func TestLoad_EnvOverridesLLM(t *testing.T) {
+	home := t.TempDir()
+	isolateEnv(t, home)
+
+	t.Setenv("DOCSIQ_LLM_OLLAMA_CHAT_MODEL", "envtest-chat")
+	t.Setenv("DOCSIQ_LLM_OLLAMA_EMBED_MODEL", "envtest-embed")
+	t.Setenv("DOCSIQ_LLM_PROVIDER", "azure")
+	t.Setenv("DOCSIQ_LLM_AZURE_API_KEY", "envtest-azure-key")
+	t.Setenv("DOCSIQ_LLM_AZURE_ENDPOINT", "https://envtest.openai.azure.com/")
+	t.Setenv("DOCSIQ_LLM_AZURE_CHAT_MODEL", "envtest-azure-chat")
+	t.Setenv("DOCSIQ_LLM_AZURE_EMBED_MODEL", "envtest-azure-embed")
+	t.Setenv("DOCSIQ_DATA_DIR", filepath.Join(home, "envtest-data"))
+
+	cfg, err := Load("")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	// Ollama keys must round-trip even when provider is azure — the
+	// fix is about *reachability* of the keys, not which one is active.
+	if got, want := cfg.LLM.Ollama.ChatModel, "envtest-chat"; got != want {
+		t.Errorf("LLM.Ollama.ChatModel = %q, want %q", got, want)
+	}
+	if got, want := cfg.LLM.Ollama.EmbedModel, "envtest-embed"; got != want {
+		t.Errorf("LLM.Ollama.EmbedModel = %q, want %q", got, want)
+	}
+	if got, want := cfg.LLM.Provider, "azure"; got != want {
+		t.Errorf("LLM.Provider = %q, want %q", got, want)
+	}
+	if got, want := cfg.LLM.Azure.APIKey, "envtest-azure-key"; got != want {
+		t.Errorf("LLM.Azure.APIKey = %q, want %q", got, want)
+	}
+	if got, want := cfg.DataDir, filepath.Join(home, "envtest-data"); got != want {
+		t.Errorf("DataDir = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Summary

Two bugs reported by a user installing v0.1.3 in a corporate environment.

**Bug 1 — `DOCSIQ_LLM_*` env vars silently ignored without a config file.**
Viper's `AutomaticEnv()` + `Unmarshal()` only reads env for keys that are explicitly bound via `BindEnv` (or already present in the merged config tree) — see [Viper #761](https://github.com/spf13/viper/issues/761). Of all the LLM keys, only `llm.call_timeout` was bound, so `DOCSIQ_LLM_PROVIDER`, `DOCSIQ_LLM_OLLAMA_*`, `DOCSIQ_LLM_AZURE_*`, `DOCSIQ_LLM_OPENAI_*` were dropped for users without `~/.docsiq/config.yaml`.

Fix: walk `v.AllKeys()` after all `SetDefault` calls and `BindEnv` each. The existing explicit `BindEnv` list stays — it documents the `DOCSIQ_API_KEY` alias for `server.api_key` and double-binds harmlessly.

**Bug 2 — `go install ...@v0.1.3` produces a binary that fails at runtime.**
The user hits `unable to open store: no such module: fts5` because `mattn/go-sqlite3` only enables FTS5 with `-tags=sqlite_fts5`. The Makefile sets that tag; `go install` doesn't pick up Makefile tags. Docs-only fix: `docs/getting-started.md` now shows `GOFLAGS='-tags=sqlite_fts5' go install ...@latest` with a one-paragraph explanation of why the tag is required.

## Files changed (3)

- `internal/config/config.go` — `for _, key := range v.AllKeys() { _ = v.BindEnv(key) }` after defaults.
- `internal/config/config_test.go` — new `TestLoad_EnvOverridesLLM` regression covering provider, Ollama, Azure, DataDir without a config file.
- `docs/getting-started.md` — `go install` line uses `GOFLAGS='-tags=sqlite_fts5'`; build-from-checkout `go build` line gains the tag for consistency.

## Test plan

- [x] `make vet` clean.
- [x] `make build` clean.
- [x] `make test` green; new `TestLoad_EnvOverridesLLM` passes.
- [x] End-to-end smoke against a fresh binary on `:37789` with `DOCSIQ_LLM_PROVIDER=ollama DOCSIQ_LLM_OLLAMA_EMBED_MODEL=bge-m3` and no config file. Server log shows `⚙️ LLM provider initialised provider=ollama model=bge-m3` — confirms the env value flows into the resolved config.
- [x] Production server on `:37777` was not touched.

## Out of scope

- Vendoring (`go mod vendor`) — v0.2.0.
- Swapping `mattn/go-sqlite3` for `modernc.org/sqlite` — separate, larger change.
- The `documents.file_hash UNIQUE` collision on `--force`, case-sensitive `/api/graph/neighborhood`, community-finalize duplicate rows, and Upload SSE 202-vs-partial-fail status — all tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)