### PR TITLE
ci(release): bake ui/dist into tagged commit so go install ships UI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,11 @@ name: release
 # Manually-triggered stable release. Pick a bump (patch/minor/major) —
 # the next vX.Y.Z tag is computed from the latest stable tag. The `notes`
 # input is used verbatim as the release body and is also attached to the
-# release as `CHANGELOG.md`. Nothing is committed back to the repo.
+# release as `CHANGELOG.md`. An ephemeral release commit (with the built
+# ui/dist/ force-added past .gitignore) is created on a detached HEAD and
+# the new tag points to *that* commit, so `go install ...@vX.Y.Z` resolves
+# a tree containing the embedded UI assets. Main itself is never modified
+# — only the tag is pushed to origin.
 on:
   workflow_dispatch:
     inputs:
@@ -219,12 +223,29 @@ jobs:
           done
           ls -la
 
-      - name: Create + push tag
+      - name: Download ui-dist for release commit
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: ui-dist
+          path: ui/dist
+
+      - name: Bake ui/dist into release commit and tag it
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ needs.tag.outputs.tag }}
         run: |
           set -eu
+          # ui/dist/ is gitignored on main, so a `go install ...@TAG`
+          # against the main tree would embed only a placeholder
+          # index.html and 404 on every /assets/* request. Create an
+          # ephemeral commit on a detached HEAD that force-includes the
+          # built ui/dist/, tag that commit as $TAG, and push the tag
+          # only — main itself is never modified.
+          git config user.name  'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git checkout --detach
+          git add -f ui/dist
+          git commit -m "release: bake ui/dist for ${TAG}"
           git tag "$TAG"
           git push origin "$TAG"
 


### PR DESCRIPTION
## Summary

- Today's release workflow tags `main` HEAD. `main`'s tree gitignores every file under `ui/dist/` except a placeholder `index.html`, so `go install github.com/RandomCodeSpace/docsiq@vX.Y.Z` resolves a tree that embeds an empty UI — the binary 404s on every `/assets/*` request.
- This PR makes the `release:` job download the `ui-dist` artifact, create an ephemeral commit on a detached HEAD with `ui/dist/` force-added past `.gitignore`, then tag *that* commit as `$TAG` and push only the tag.
- `main` itself is never modified — only the new tag is pushed to origin. `proxy.golang.org` sees the tagged tree (with embedded UI), so `go install ...@vX.Y.Z` produces a working binary.
- Prebuilt signed release binaries are unaffected — CI already runs `npm run build` before `go build`.

## Why this approach

Two alternatives considered and rejected:

1. **Commit `ui/dist/` to `main`.** Bloats every PR diff with hashed bundle changes; couples source-of-truth to build output. Closed as PR #96.
2. **Don't embed UI; ship a separate `--ui-dir` flag.** Breaks the single-binary distribution promise.

Tagging an off-main commit keeps `main` clean *and* gives `go install` a tree it can actually use.

## Test plan

- [ ] Dispatch `release.yml` with `bump=patch` to cut `v0.1.5`
- [ ] Workflow succeeds end-to-end (UI build, binary build, sign, tag, release)
- [ ] `git ls-tree v0.1.5 -- ui/dist/` lists `index.html` AND `assets/*.js`, `assets/*.css`
- [ ] `git ls-tree origin/main -- ui/dist/` still shows only `index.html` (main untouched)
- [ ] Fresh `GOPATH=/tmp/gopath GOFLAGS='-tags=sqlite_fts5' go install github.com/RandomCodeSpace/docsiq@v0.1.5` produces a binary
- [ ] `docsiq serve --port 37792` from that binary returns HTTP 200 on `GET /` and on at least 4 `/assets/<hash>.{js,css}` paths
- [ ] Prebuilt signed `docsiq-v0.1.5-linux-amd64` still verifies via the cosign command in the release notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)