### PR TITLE
chore(security): suppress two Semgrep filepath-clean false positives with inline reasons

### DIFF
--- a/internal/api/notes_handlers.go
+++ b/internal/api/notes_handlers.go
@@ -485,8 +485,14 @@ func (h *notesHandlers) importTar(w http.ResponseWriter, r *http.Request) {
 				fmt.Sprintf("too many entries (cap %d)", MaxImportEntries), nil)
 			return
 		}
+		// Clean is for normalisation here, not the security boundary.
+		// The traversal defence is the explicit reject below (HasPrefix
+		// "/" + Contains "..") followed by an absolute-path containment
+		// check after filepath.Join into notesDir. All three layers must
+		// fail simultaneously for a traversal to land — Semgrep can't see
+		// the multi-statement defence, so the rule is suppressed inline.
+		// nosemgrep: go.lang.security.filepath-clean-misuse.filepath-clean-misuse
 		name := filepath.ToSlash(filepath.Clean(hdr.Name))
-		// Reject traversal / absolute paths in archive entries.
 		if strings.HasPrefix(name, "/") || strings.Contains(name, "..") {
 			writeError(w, r, http.StatusForbidden,
 				"tar entry traversal: "+hdr.Name, nil)
@@ -496,7 +502,6 @@ func (h *notesHandlers) importTar(w http.ResponseWriter, r *http.Request) {
 			continue
 		}
 		dest := filepath.Join(notesDir, filepath.FromSlash(name))
-		// Double-check containment (defense in depth).
 		absDest, _ := filepath.Abs(dest)
 		absBase, _ := filepath.Abs(notesDir)
 		if !strings.HasPrefix(absDest, absBase+string(os.PathSeparator)) {

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -234,6 +234,13 @@ func spaHandler(assets fs.FS, _ *config.Config) http.Handler {
 			return
 		}
 
+		// path.Clean here normalises a URL path for SPA-vs-asset
+		// classification — it is not the security boundary. The handler
+		// only reads from `assets fs.FS`, which is fs.Sub(embed.FS, "dist"):
+		// io/fs rejects any path containing ".." via fs.ValidPath, and
+		// embed.FS holds only compile-time files. Path traversal cannot
+		// reach the host filesystem regardless of what cleanPath becomes.
+		// nosemgrep: go.lang.security.filepath-clean-misuse.filepath-clean-misuse
 		cleanPath := strings.TrimPrefix(path.Clean(r.URL.Path), "/")
 		if cleanPath == "." || cleanPath == "" {
 			cleanPath = "index.html"


### PR DESCRIPTION
## Summary

Semgrep's `go.lang.security.filepath-clean-misuse` rule fires on every `filepath.Clean` / `path.Clean` call on user-controlled input regardless of surrounding defence. Two sites in this repo trip the rule but are safe by construction; this PR adds inline `// nosemgrep:` annotations with the reasoning captured next to the call rather than rewriting working code to placate a single-statement linter.

## Findings handled

### `internal/api/notes_handlers.go:488` (tar import)

`Clean` here normalises `hdr.Name`; it is **not** the security boundary. The actual defence is three layers:

1. Explicit reject of any name with a `/` prefix or `..` substring (immediately after the Clean)
2. `filepath.Join(notesDir, ...)` then `filepath.Abs` containment check (`absDest` must start with `absBase + os.PathSeparator`)
3. Reader is bounded by `MaxNoteBytes` so a malicious entry can't cause a write blow-up either

All three must fail simultaneously for a traversal to land — Semgrep sees only the first statement.

### `internal/api/router.go:237` (SPA file server)

`Clean` here normalises a URL path for SPA-vs-asset classification. The handler reads only from `assets fs.FS`, which is `fs.Sub(embed.FS, "dist")` (see `ui/embed.go`). Two architectural guarantees apply:

- `io/fs` rejects any path containing `..` via `fs.ValidPath` before it reaches `embed.FS`
- `embed.FS` only contains files baked in at compile time — there is no host-filesystem reachability regardless of what `cleanPath` ends up

Path traversal is not possible here.

## Why suppress instead of "fix"

Semgrep's autofix in both cases is `filepath.FromSlash(path.Clean(...))`, which doesn't change the threat model — it just shuts the linter up. The recommended `cyphar/filepath-securejoin` would add a dependency and replace working multi-layer defence with a single library call that is no stronger here. The right answer is to keep the existing defence and document why the rule doesn't apply, which is what this PR does.

## Test plan

- [x] `go vet -tags sqlite_fts5 ./internal/api/...` clean
- [x] `go build -tags sqlite_fts5 ./internal/api/...` clean
- [x] Pre-existing tar-import + SPA tests still pass (no behaviour change)
- [ ] CI's Semgrep job goes green on this branch (the merge gate)

## Compatibility

Drop-in. Pure documentation/comment changes — no behaviour change. Two pre-existing one-line comments at the same sites are folded into the new explanatory blocks; nothing else moves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)