### PR TITLE
fix(ui): extract theme-flash inline script to /theme-flash.js for strict CSP

### DIFF
--- a/ui/dist/index.html
+++ b/ui/dist/index.html
@@ -11,10 +11,18 @@
     <link rel="apple-touch-icon" href="/favicon.svg" />
     <link rel="manifest" href="/manifest.webmanifest" />
     <title>docsiq — GraphRAG knowledge base</title>
-    <script type="module" crossorigin src="/assets/index-BYq_8sLj.js"></script>
+    <!--
+      Theme-flash guard moved out of an inline <script> so the strict
+      CSP (script-src 'self', no 'unsafe-inline') accepts it. Vite
+      copies ui/public/theme-flash.js to /theme-flash.js at build
+      time. Loaded synchronously here so it executes before the SPA
+      hydrates and prevents FOUC.
+    -->
+    <script src="/theme-flash.js"></script>
+    <script type="module" crossorigin src="/assets/index-Dtmrigu0.js"></script>
     <link rel="modulepreload" crossorigin href="/assets/rolldown-runtime-S-ySWqyJ.js">
     <link rel="modulepreload" crossorigin href="/assets/graph-YlRq3euP.js">
-    <link rel="stylesheet" crossorigin href="/assets/index-DBMDkFdw.css">
+    <link rel="stylesheet" crossorigin href="/assets/index-BZYFJ-vO.css">
   </head>
   <body>
     <div id="root"></div>

--- a/ui/index.html
+++ b/ui/index.html
@@ -11,37 +11,14 @@
     <link rel="apple-touch-icon" href="/favicon.svg" />
     <link rel="manifest" href="/manifest.webmanifest" />
     <title>docsiq — GraphRAG knowledge base</title>
-    <script>
-      // Block 5.9 — theme-flash guard. Applies the persisted theme class
-      // before React hydrates so there is no FOUC on first paint. Must run
-      // synchronously in <head>. Keep in sync with Zustand persist key
-      // `docsiq-ui` and the Providers.tsx effect that toggles .dark.
-      (function () {
-        try {
-          var raw = localStorage.getItem("docsiq-ui");
-          var theme = "system";
-          if (raw) {
-            var parsed = JSON.parse(raw);
-            if (parsed && parsed.state && typeof parsed.state.theme === "string") {
-              theme = parsed.state.theme;
-            }
-          }
-          var effective = theme;
-          if (theme === "system") {
-            effective = window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches
-              ? "dark"
-              : "light";
-          }
-          var root = document.documentElement;
-          root.dataset.theme = effective;
-          if (effective === "dark") root.classList.add("dark");
-        } catch (e) {
-          // If localStorage is unavailable (privacy mode) we simply let
-          // React decide after hydration; there is a brief FOUC but no
-          // crash. Do not log — this runs before any logger is attached.
-        }
-      })();
-    </script>
+    <!--
+      Theme-flash guard moved out of an inline <script> so the strict
+      CSP (script-src 'self', no 'unsafe-inline') accepts it. Vite
+      copies ui/public/theme-flash.js to /theme-flash.js at build
+      time. Loaded synchronously here so it executes before the SPA
+      hydrates and prevents FOUC.
+    -->
+    <script src="/theme-flash.js"></script>
   </head>
   <body>
     <div id="root"></div>

--- a/ui/public/theme-flash.js
+++ b/ui/public/theme-flash.js
@@ -1,0 +1,32 @@
+// Theme-flash guard. Applies the persisted theme class before React
+// hydrates so there is no FOUC on first paint. Runs synchronously
+// from <head> via <script src="/theme-flash.js">. Lives in public/
+// (not src/) so it is served as a static asset and the strict CSP
+// (script-src 'self') accepts it without an inline-script exception.
+// Keep in sync with the Zustand persist key `docsiq-ui` and the
+// Providers.tsx effect that toggles `.dark`.
+(function () {
+  try {
+    var raw = localStorage.getItem("docsiq-ui");
+    var theme = "system";
+    if (raw) {
+      var parsed = JSON.parse(raw);
+      if (parsed && parsed.state && typeof parsed.state.theme === "string") {
+        theme = parsed.state.theme;
+      }
+    }
+    var effective = theme;
+    if (theme === "system") {
+      effective =
+        window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches
+          ? "dark"
+          : "light";
+    }
+    var root = document.documentElement;
+    root.dataset.theme = effective;
+    if (effective === "dark") root.classList.add("dark");
+  } catch (e) {
+    // localStorage unavailable (privacy mode) — let React decide
+    // after hydration; brief FOUC but no crash. Do not log.
+  }
+})();


### PR DESCRIPTION
## Summary

The strict CSP shipped from `internal/api/security_headers.go` uses:

```
script-src 'self' 'wasm-unsafe-eval'
```

— no `'unsafe-inline'`. The theme-flash FOUC guard in `ui/index.html` was an inline `<script>` block, so every page load logged a CSP violation:

> Refused to execute inline script because it violates the following Content Security Policy directive: `script-src 'self' 'wasm-unsafe-eval'`

The script never ran, which meant a brief flash-of-wrong-theme on first paint when the user's persisted choice differed from the OS preference.

## Fix

Move the script body verbatim into `ui/public/theme-flash.js` (Vite copies `public/` to `/dist` root at build time) and reference it from `index.html` via:

```html
<script src="/theme-flash.js"></script>
```

CSP `'self'` allows it without an `'unsafe-inline'` exception. The script body is unchanged, so behavior is identical when it runs.

The `ui/dist/index.html` placeholder (committed for `//go:embed ui/dist`) is updated to match the new structure.

## Trade-off

One extra HTTP/2 request before paint for `/theme-flash.js` (1.2 KiB). Well below the perceptible-jank threshold and worth keeping the strict CSP intact. Could be eliminated with a CSP `script-src` SHA-256 hash, but that introduces hash-sync coupling between the Go server and the JS file — not worth it for a 1.2 KiB script that rarely changes.

## Test plan

- [x] `npm --prefix ui run build` produces `dist/theme-flash.js` (1.2 KiB)
- [x] `dist/index.html` no longer contains the inline `<script>` block
- [x] `dist/index.html` contains `<script src=\"/theme-flash.js\">`
- [x] `go build -tags sqlite_fts5` clean
- [x] Local smoke: `docsiq serve --port 37794` returns HTTP 200 on `/` AND `/theme-flash.js` (200, 1227 bytes)
- [x] CSP header on `/` unchanged
- [ ] Post-merge browser smoke: dev tools console clean of inline-script CSP violations
- [ ] Post-merge: dark-mode-persisted user reloads in fresh tab, no flash-of-light-mode

## Compatibility

Drop-in. Behavior of the script is identical; only the delivery mechanism changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)