### PR TITLE
feat(documents): DELETE /api/documents/{id} with graph-cascade cleanup

### DIFF
--- a/internal/api/document_delete_test.go
+++ b/internal/api/document_delete_test.go
@@ -1,0 +1,265 @@
+//go:build sqlite_fts5
+
+package api
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/RandomCodeSpace/docsiq/internal/config"
+	"github.com/RandomCodeSpace/docsiq/internal/store"
+)
+
+// seedDeleteFixture creates a router with two documents, two chunks
+// each, claims and relationships rooted in each doc, and one entity
+// shared across both docs plus one entity unique to doc-A. The shared
+// entity must survive deletion of doc-A; the unique entity must not.
+func seedDeleteFixture(t *testing.T) (http.Handler, *store.Store) {
+	t.Helper()
+	dir := t.TempDir()
+	st, err := store.OpenForProject(dir, "_default")
+	if err != nil {
+		t.Fatalf("OpenForProject: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+
+	ctx := context.Background()
+	for _, d := range []*store.Document{
+		{ID: "docA", Path: "/tmp/a.md", DocType: "md", FileHash: "ah", IsLatest: true},
+		{ID: "docB", Path: "/tmp/b.md", DocType: "md", FileHash: "bh", IsLatest: true},
+	} {
+		if err := st.UpsertDocument(ctx, d); err != nil {
+			t.Fatalf("UpsertDocument %s: %v", d.ID, err)
+		}
+	}
+
+	chunks := []*store.Chunk{
+		{ID: "cA1", DocID: "docA", ChunkIndex: 0, Content: "alpha-1"},
+		{ID: "cA2", DocID: "docA", ChunkIndex: 1, Content: "alpha-2"},
+		{ID: "cB1", DocID: "docB", ChunkIndex: 0, Content: "beta-1"},
+	}
+	if err := st.BatchInsertChunks(ctx, chunks); err != nil {
+		t.Fatalf("BatchInsertChunks: %v", err)
+	}
+	if err := st.BatchUpsertEmbeddings(ctx, "test-model",
+		[]string{"cA1", "cA2", "cB1"},
+		[][]float32{{0.1, 0.2}, {0.3, 0.4}, {0.5, 0.6}}); err != nil {
+		t.Fatalf("BatchUpsertEmbeddings: %v", err)
+	}
+
+	// Entities: shared (referenced by both docs) and unique-to-A.
+	for _, e := range []*store.Entity{
+		{ID: "eShared", Name: "Shared"},
+		{ID: "eOnlyA", Name: "OnlyA"},
+		{ID: "eOnlyB", Name: "OnlyB"},
+	} {
+		if err := st.UpsertEntity(ctx, e); err != nil {
+			t.Fatalf("UpsertEntity %s: %v", e.ID, err)
+		}
+	}
+
+	rels := []*store.Relationship{
+		{ID: "rA1", SourceID: "eShared", TargetID: "eOnlyA", Predicate: "mentions", DocID: "docA"},
+		{ID: "rA2", SourceID: "eOnlyA", TargetID: "eShared", Predicate: "rel", DocID: "docA"},
+		{ID: "rB1", SourceID: "eShared", TargetID: "eOnlyB", Predicate: "mentions", DocID: "docB"},
+	}
+	if err := st.BatchInsertRelationships(ctx, rels); err != nil {
+		t.Fatalf("BatchInsertRelationships: %v", err)
+	}
+
+	claims := []*store.Claim{
+		{ID: "clA", EntityID: "eOnlyA", Claim: "claim-a", Status: "verified", DocID: "docA"},
+		{ID: "clB", EntityID: "eOnlyB", Claim: "claim-b", Status: "verified", DocID: "docB"},
+	}
+	if err := st.BatchInsertClaims(ctx, claims); err != nil {
+		t.Fatalf("BatchInsertClaims: %v", err)
+	}
+
+	cfg := &config.Config{}
+	cfg.DataDir = dir
+	h := NewRouter(nil, nil, cfg, nil,
+		WithProjectStores(testSingleStore(dir, st, "_default")))
+	return h, st
+}
+
+func TestDeleteDocumentHandler(t *testing.T) {
+	t.Run("unknown_id_returns_404", func(t *testing.T) {
+		h, _ := seedDeleteFixture(t)
+		req := httptest.NewRequest(http.MethodDelete, "/api/documents/no-such-id", nil)
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		if rec.Code != http.StatusNotFound {
+			t.Fatalf("status = %d, want 404; body=%s", rec.Code, rec.Body.String())
+		}
+	})
+
+	t.Run("happy_path_returns_204_and_cleans_graph", func(t *testing.T) {
+		h, st := seedDeleteFixture(t)
+		req := httptest.NewRequest(http.MethodDelete, "/api/documents/docA", nil)
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		if rec.Code != http.StatusNoContent {
+			t.Fatalf("status = %d, want 204; body=%s", rec.Code, rec.Body.String())
+		}
+		if rec.Body.Len() != 0 {
+			t.Errorf("body = %q, want empty for 204", rec.Body.String())
+		}
+
+		ctx := context.Background()
+
+		// docA gone, docB preserved.
+		if d, err := st.GetDocument(ctx, "docA"); err != nil || d != nil {
+			t.Errorf("docA still present (err=%v, doc=%v)", err, d)
+		}
+		if d, err := st.GetDocument(ctx, "docB"); err != nil || d == nil {
+			t.Errorf("docB unexpectedly removed (err=%v, doc=%v)", err, d)
+		}
+
+		// Chunks for docA gone, docB chunk preserved.
+		aChunks, _ := st.ListChunksByDoc(ctx, "docA")
+		if len(aChunks) != 0 {
+			t.Errorf("docA chunks remain: %d", len(aChunks))
+		}
+		bChunks, _ := st.ListChunksByDoc(ctx, "docB")
+		if len(bChunks) != 1 {
+			t.Errorf("docB chunks count = %d, want 1", len(bChunks))
+		}
+
+		// Embeddings for docA chunks gone (cascade via FK).
+		var embCount int
+		row := st.DB().QueryRowContext(ctx,
+			`SELECT COUNT(*) FROM embeddings WHERE chunk_id IN ('cA1','cA2')`)
+		if err := row.Scan(&embCount); err != nil {
+			t.Fatalf("embeddings count: %v", err)
+		}
+		if embCount != 0 {
+			t.Errorf("docA embeddings remain: %d", embCount)
+		}
+
+		// Claims/relationships for docA gone, docB preserved.
+		var relCount int
+		_ = st.DB().QueryRowContext(ctx,
+			`SELECT COUNT(*) FROM relationships WHERE doc_id='docA'`).Scan(&relCount)
+		if relCount != 0 {
+			t.Errorf("docA relationships remain: %d", relCount)
+		}
+		var bRelCount int
+		_ = st.DB().QueryRowContext(ctx,
+			`SELECT COUNT(*) FROM relationships WHERE doc_id='docB'`).Scan(&bRelCount)
+		if bRelCount != 1 {
+			t.Errorf("docB relationships count = %d, want 1", bRelCount)
+		}
+		var aClaimCount int
+		_ = st.DB().QueryRowContext(ctx,
+			`SELECT COUNT(*) FROM claims WHERE doc_id='docA'`).Scan(&aClaimCount)
+		if aClaimCount != 0 {
+			t.Errorf("docA claims remain: %d", aClaimCount)
+		}
+
+		// Orphan entity (eOnlyA) removed; shared (eShared) and
+		// docB-only (eOnlyB) preserved.
+		if e, err := st.GetEntity(ctx, "eOnlyA"); err != nil || e != nil {
+			t.Errorf("orphan entity eOnlyA still present (err=%v, ent=%v)", err, e)
+		}
+		if e, err := st.GetEntity(ctx, "eShared"); err != nil || e == nil {
+			t.Errorf("shared entity eShared was removed (err=%v, ent=%v)", err, e)
+		}
+		if e, err := st.GetEntity(ctx, "eOnlyB"); err != nil || e == nil {
+			t.Errorf("docB-only entity eOnlyB was removed (err=%v, ent=%v)", err, e)
+		}
+	})
+
+	t.Run("idempotent_after_delete", func(t *testing.T) {
+		h, _ := seedDeleteFixture(t)
+		req1 := httptest.NewRequest(http.MethodDelete, "/api/documents/docA", nil)
+		rec1 := httptest.NewRecorder()
+		h.ServeHTTP(rec1, req1)
+		if rec1.Code != http.StatusNoContent {
+			t.Fatalf("first delete status = %d, want 204", rec1.Code)
+		}
+		// Second delete of the same id must be 404, not 204.
+		req2 := httptest.NewRequest(http.MethodDelete, "/api/documents/docA", nil)
+		rec2 := httptest.NewRecorder()
+		h.ServeHTTP(rec2, req2)
+		if rec2.Code != http.StatusNotFound {
+			t.Fatalf("second delete status = %d, want 404", rec2.Code)
+		}
+	})
+}
+
+// TestStoreDeleteDocumentCascade is a thin store-layer fence around
+// the cascade transaction so a future schema change that breaks the
+// graph cleanup fails here, not just at the HTTP boundary.
+func TestStoreDeleteDocumentCascade(t *testing.T) {
+	dir := t.TempDir()
+	st, err := store.OpenForProject(dir, "tx")
+	if err != nil {
+		t.Fatalf("OpenForProject: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+
+	ctx := context.Background()
+	if err := st.UpsertDocument(ctx, &store.Document{
+		ID: "d1", Path: "/p.md", DocType: "md", FileHash: "h1", IsLatest: true,
+	}); err != nil {
+		t.Fatalf("UpsertDocument: %v", err)
+	}
+	if err := st.BatchInsertChunks(ctx, []*store.Chunk{
+		{ID: "ch1", DocID: "d1", ChunkIndex: 0, Content: "x"},
+	}); err != nil {
+		t.Fatalf("BatchInsertChunks: %v", err)
+	}
+	if err := st.UpsertEntity(ctx, &store.Entity{ID: "e1", Name: "E1"}); err != nil {
+		t.Fatalf("UpsertEntity: %v", err)
+	}
+	if err := st.BatchInsertRelationships(ctx, []*store.Relationship{
+		{ID: "r1", SourceID: "e1", TargetID: "e1", Predicate: "self", DocID: "d1"},
+	}); err != nil {
+		t.Fatalf("BatchInsertRelationships: %v", err)
+	}
+	if err := st.BatchInsertClaims(ctx, []*store.Claim{
+		{ID: "cl1", EntityID: "e1", Claim: "c", Status: "v", DocID: "d1"},
+	}); err != nil {
+		t.Fatalf("BatchInsertClaims: %v", err)
+	}
+
+	affected, err := st.DeleteDocument(ctx, "d1")
+	if err != nil {
+		t.Fatalf("DeleteDocument: %v", err)
+	}
+	if affected != 1 {
+		t.Errorf("affected = %d, want 1", affected)
+	}
+
+	// Everything tied to d1 must be gone, including the now-orphan
+	// entity e1.
+	for _, q := range []struct {
+		name string
+		sql  string
+	}{
+		{"chunks", `SELECT COUNT(*) FROM chunks WHERE doc_id='d1'`},
+		{"relationships", `SELECT COUNT(*) FROM relationships WHERE doc_id='d1'`},
+		{"claims", `SELECT COUNT(*) FROM claims WHERE doc_id='d1'`},
+		{"entities", `SELECT COUNT(*) FROM entities WHERE id='e1'`},
+		{"documents", `SELECT COUNT(*) FROM documents WHERE id='d1'`},
+	} {
+		var n int
+		if err := st.DB().QueryRowContext(ctx, q.sql).Scan(&n); err != nil {
+			t.Fatalf("count %s: %v", q.name, err)
+		}
+		if n != 0 {
+			t.Errorf("%s count = %d, want 0", q.name, n)
+		}
+	}
+
+	// Idempotent: deleting an unknown id is a 0-affected non-error.
+	affected, err = st.DeleteDocument(ctx, "missing")
+	if err != nil {
+		t.Errorf("delete missing returned err: %v", err)
+	}
+	if affected != 0 {
+		t.Errorf("delete missing affected = %d, want 0", affected)
+	}
+}

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -252,6 +252,64 @@ func (h *handlers) getDocumentChunks(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, 200, out)
 }
 
+// deleteDocument hard-deletes a document and cascades cleanup of
+// chunks, embeddings, claims, doc-scoped relationships, and any
+// entities that no longer have a relationship or claim referencing
+// them.
+//
+// Communities are deliberately NOT recomputed inline. Louvain on a
+// graph of any meaningful size is too slow for an interactive DELETE,
+// and stale community titles/summaries are tolerable until the next
+// manual finalize. The vector index is invalidated so the next search
+// rebuilds against the post-delete chunk set.
+//
+// Returns 204 on success, 404 if the id does not exist, 500 on
+// transactional failure (the store rolls back so the graph stays
+// consistent).
+func (h *handlers) deleteDocument(w http.ResponseWriter, r *http.Request) {
+	st, ok := h.resolveStore(w, r)
+	if !ok {
+		return
+	}
+	id := r.PathValue("id")
+	doc, err := st.GetDocument(r.Context(), id)
+	if err != nil {
+		writeError(w, r, 500, err.Error(), err)
+		return
+	}
+	if doc == nil {
+		writeError(w, r, 404, "document not found", nil)
+		return
+	}
+
+	affected, err := st.DeleteDocument(r.Context(), id)
+	if err != nil {
+		writeError(w, r, 500, fmt.Errorf("delete document: %w", err).Error(), err)
+		return
+	}
+	if affected == 0 {
+		// Race: the row vanished between our GetDocument and the
+		// delete. Treat as 404 — the operation succeeded only if it
+		// actually removed something.
+		writeError(w, r, 404, "document not found", nil)
+		return
+	}
+
+	// Drop the cached vector index for this project so the next local
+	// search rebuilds against the post-delete chunk set. Safe on a nil
+	// receiver.
+	slug := ProjectFromContext(r.Context())
+	h.vecIndexes.Invalidate(slug)
+
+	slog.Info("🗑️  document deleted",
+		"project", slug,
+		"doc_id", id,
+		"path", doc.Path,
+	)
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
 func (h *handlers) entityGraph(w http.ResponseWriter, r *http.Request) {
 	st, ok := h.resolveStore(w, r)
 	if !ok {

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -169,6 +169,7 @@ func NewRouter(prov llm.Provider, emb *embedder.Embedder, cfg *config.Config, re
 	mux.HandleFunc("GET /api/stats", h.getStats)
 	mux.HandleFunc("GET /api/documents", h.listDocuments)
 	mux.HandleFunc("GET /api/documents/{id}", h.getDocument)
+	mux.HandleFunc("DELETE /api/documents/{id}", h.deleteDocument)
 	mux.HandleFunc("GET /api/documents/{id}/chunks", h.getDocumentChunks)
 	mux.HandleFunc("GET /api/documents/{id}/versions", h.getDocumentVersions)
 	mux.HandleFunc("POST /api/search", h.search)

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -441,16 +441,70 @@ func (s *Store) ListDocuments(ctx context.Context, docType string, limit, offset
 	return docs, rows.Err()
 }
 
-// DeleteDocument hard-deletes a document row. ON DELETE CASCADE on
-// chunks/embeddings/relationships takes care of dependent rows.
-// Returns the number of rows removed so callers can distinguish "did
-// nothing" from "did something."
+// DeleteDocument hard-deletes a document and cascades cleanup of
+// graph artifacts that came from it. Runs as a single SQLite
+// transaction so partial failures roll back.
+//
+// Cascade order:
+//  1. relationships WHERE doc_id=?  — drop edges sourced from this doc
+//  2. claims        WHERE doc_id=?  — drop claims sourced from this doc
+//  3. chunks        WHERE doc_id=?  — embeddings cascade via FK
+//  4. documents     WHERE id=?      — the row itself
+//  5. orphan entities — entities with no remaining relationship or
+//     claim references are deleted; community_members rows cascade
+//     via FK so the graph stays consistent
+//
+// Communities are deliberately NOT recomputed here. Stale community
+// summaries are tolerable until the next manual `community.finalize`;
+// recomputing on every delete would dominate the request budget for
+// users dropping a bad upload. Trade-off documented in the API
+// handler comment as well.
+//
+// Returns the number of document rows removed (0 if the id did not
+// exist) so callers can distinguish "did nothing" from "did something."
 func (s *Store) DeleteDocument(ctx context.Context, id string) (int64, error) {
-	res, err := s.db.ExecContext(ctx, `DELETE FROM documents WHERE id=?`, id)
+	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
-		return 0, err
+		return 0, fmt.Errorf("begin tx: %w", err)
 	}
-	return res.RowsAffected()
+	defer tx.Rollback()
+
+	if _, err := tx.ExecContext(ctx, `DELETE FROM relationships WHERE doc_id=?`, id); err != nil {
+		return 0, fmt.Errorf("delete relationships: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `DELETE FROM claims WHERE doc_id=?`, id); err != nil {
+		return 0, fmt.Errorf("delete claims: %w", err)
+	}
+	// chunks cascade-deletes embeddings via embeddings.chunk_id FK.
+	if _, err := tx.ExecContext(ctx, `DELETE FROM chunks WHERE doc_id=?`, id); err != nil {
+		return 0, fmt.Errorf("delete chunks: %w", err)
+	}
+	res, err := tx.ExecContext(ctx, `DELETE FROM documents WHERE id=?`, id)
+	if err != nil {
+		return 0, fmt.Errorf("delete document: %w", err)
+	}
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf("rows affected: %w", err)
+	}
+
+	// Orphan entity sweep: an entity is orphan when no remaining row
+	// in relationships (as source or target) or claims still
+	// references it. Entities are deduped by name across docs, so
+	// shared entities (e.g. "OpenAI" mentioned in two unrelated docs)
+	// remain after deleting one of those docs.
+	if _, err := tx.ExecContext(ctx, `
+		DELETE FROM entities
+		WHERE id NOT IN (SELECT source_id FROM relationships)
+		  AND id NOT IN (SELECT target_id FROM relationships)
+		  AND id NOT IN (SELECT entity_id FROM claims WHERE entity_id IS NOT NULL)`); err != nil {
+		return 0, fmt.Errorf("sweep orphan entities: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return 0, fmt.Errorf("commit: %w", err)
+	}
+	return affected, nil
 }
 
 // AllDocuments returns every row in the documents table regardless of

--- a/ui/dist/index.html
+++ b/ui/dist/index.html
@@ -11,10 +11,18 @@
     <link rel="apple-touch-icon" href="/favicon.svg" />
     <link rel="manifest" href="/manifest.webmanifest" />
     <title>docsiq — GraphRAG knowledge base</title>
-    <script type="module" crossorigin src="/assets/index-BYq_8sLj.js"></script>
+    <!--
+      Theme-flash guard moved out of an inline <script> so the strict
+      CSP (script-src 'self', no 'unsafe-inline') accepts it. Vite
+      copies ui/public/theme-flash.js to /theme-flash.js at build
+      time. Loaded synchronously here so it executes before the SPA
+      hydrates and prevents FOUC.
+    -->
+    <script src="/theme-flash.js"></script>
+    <script type="module" crossorigin src="/assets/index-Dtmrigu0.js"></script>
     <link rel="modulepreload" crossorigin href="/assets/rolldown-runtime-S-ySWqyJ.js">
     <link rel="modulepreload" crossorigin href="/assets/graph-YlRq3euP.js">
-    <link rel="stylesheet" crossorigin href="/assets/index-DBMDkFdw.css">
+    <link rel="stylesheet" crossorigin href="/assets/index-BZYFJ-vO.css">
   </head>
   <body>
     <div id="root"></div>

--- a/ui/index.html
+++ b/ui/index.html
@@ -11,37 +11,14 @@
     <link rel="apple-touch-icon" href="/favicon.svg" />
     <link rel="manifest" href="/manifest.webmanifest" />
     <title>docsiq — GraphRAG knowledge base</title>
-    <script>
-      // Block 5.9 — theme-flash guard. Applies the persisted theme class
-      // before React hydrates so there is no FOUC on first paint. Must run
-      // synchronously in <head>. Keep in sync with Zustand persist key
-      // `docsiq-ui` and the Providers.tsx effect that toggles .dark.
-      (function () {
-        try {
-          var raw = localStorage.getItem("docsiq-ui");
-          var theme = "system";
-          if (raw) {
-            var parsed = JSON.parse(raw);
-            if (parsed && parsed.state && typeof parsed.state.theme === "string") {
-              theme = parsed.state.theme;
-            }
-          }
-          var effective = theme;
-          if (theme === "system") {
-            effective = window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches
-              ? "dark"
-              : "light";
-          }
-          var root = document.documentElement;
-          root.dataset.theme = effective;
-          if (effective === "dark") root.classList.add("dark");
-        } catch (e) {
-          // If localStorage is unavailable (privacy mode) we simply let
-          // React decide after hydration; there is a brief FOUC but no
-          // crash. Do not log — this runs before any logger is attached.
-        }
-      })();
-    </script>
+    <!--
+      Theme-flash guard moved out of an inline <script> so the strict
+      CSP (script-src 'self', no 'unsafe-inline') accepts it. Vite
+      copies ui/public/theme-flash.js to /theme-flash.js at build
+      time. Loaded synchronously here so it executes before the SPA
+      hydrates and prevents FOUC.
+    -->
+    <script src="/theme-flash.js"></script>
   </head>
   <body>
     <div id="root"></div>

--- a/ui/public/theme-flash.js
+++ b/ui/public/theme-flash.js
@@ -1,0 +1,32 @@
+// Theme-flash guard. Applies the persisted theme class before React
+// hydrates so there is no FOUC on first paint. Runs synchronously
+// from <head> via <script src="/theme-flash.js">. Lives in public/
+// (not src/) so it is served as a static asset and the strict CSP
+// (script-src 'self') accepts it without an inline-script exception.
+// Keep in sync with the Zustand persist key `docsiq-ui` and the
+// Providers.tsx effect that toggles `.dark`.
+(function () {
+  try {
+    var raw = localStorage.getItem("docsiq-ui");
+    var theme = "system";
+    if (raw) {
+      var parsed = JSON.parse(raw);
+      if (parsed && parsed.state && typeof parsed.state.theme === "string") {
+        theme = parsed.state.theme;
+      }
+    }
+    var effective = theme;
+    if (theme === "system") {
+      effective =
+        window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches
+          ? "dark"
+          : "light";
+    }
+    var root = document.documentElement;
+    root.dataset.theme = effective;
+    if (effective === "dark") root.classList.add("dark");
+  } catch (e) {
+    // localStorage unavailable (privacy mode) — let React decide
+    // after hydration; brief FOUC but no crash. Do not log.
+  }
+})();

--- a/ui/src/components/layout/Providers.tsx
+++ b/ui/src/components/layout/Providers.tsx
@@ -8,6 +8,7 @@ import { useEffect, useState, type ReactNode } from "react";
 import { BrowserRouter } from "react-router-dom";
 import { useUIStore } from "@/stores/ui";
 import { useAuthStore } from "@/stores/auth";
+import { Toaster } from "@/components/ui/sonner";
 
 // Defensive 401 gate. The HTTP boundary (apiFetch / mcpRequest in
 // lib/api-client.ts) is the primary signal for AuthRequiredBanner — it
@@ -63,6 +64,7 @@ export function Providers({ children }: { children: ReactNode }) {
   return (
     <QueryClientProvider client={client}>
       <BrowserRouter>{children}</BrowserRouter>
+      <Toaster richColors position="bottom-right" />
     </QueryClientProvider>
   );
 }

--- a/ui/src/hooks/api/useDocs.ts
+++ b/ui/src/hooks/api/useDocs.ts
@@ -1,4 +1,4 @@
-import { useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { apiFetch } from "@/lib/api-client";
 import { qk } from "./keys";
 import type { Document } from "@/types/api";
@@ -39,6 +39,28 @@ export function useDocChunks(project: string, id: string | undefined) {
         `/api/documents/${encodeURIComponent(id!)}/chunks?project=${encodeURIComponent(project)}`,
       );
       return Array.isArray(res) ? res : [];
+    },
+  });
+}
+
+// useDeleteDoc returns a mutation that hard-deletes a document and
+// cascades graph cleanup on the server. Invalidates the list, the
+// per-doc cache, the stats strip, and the entity graph so every view
+// that referenced the doc re-fetches.
+export function useDeleteDoc(project: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) =>
+      apiFetch<void>(
+        `/api/documents/${encodeURIComponent(id)}?project=${encodeURIComponent(project)}`,
+        { method: "DELETE" },
+      ),
+    onSuccess: (_data, id) => {
+      qc.invalidateQueries({ queryKey: qk.docs(project) });
+      qc.invalidateQueries({ queryKey: qk.stats(project) });
+      qc.invalidateQueries({ queryKey: qk.entityGraph(project) });
+      qc.removeQueries({ queryKey: qk.doc(project, id) });
+      qc.removeQueries({ queryKey: qk.docChunks(project, id) });
     },
   });
 }

--- a/ui/src/routes/documents/DeleteDocumentDialog.tsx
+++ b/ui/src/routes/documents/DeleteDocumentDialog.tsx
@@ -1,0 +1,89 @@
+import { useState } from "react";
+import { toast } from "sonner";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { useDeleteDoc } from "@/hooks/api/useDocs";
+
+interface Props {
+  open: boolean;
+  onOpenChange: (next: boolean) => void;
+  project: string;
+  docId: string;
+  docLabel: string;
+  // Called after a successful delete settles. Use this to navigate
+  // away from a now-stale detail route.
+  onDeleted?: () => void;
+}
+
+// DeleteDocumentDialog renders a destructive confirm flow. The actual
+// mutation lives in useDeleteDoc (which invalidates the relevant query
+// keys); this component is purely UI + success/error toasting and
+// closing the dialog cleanly. We deliberately keep the mutation
+// outside the dialog so callers can pre-warm or share state if needed.
+export function DeleteDocumentDialog({
+  open,
+  onOpenChange,
+  project,
+  docId,
+  docLabel,
+  onDeleted,
+}: Props) {
+  const del = useDeleteDoc(project);
+  const [busy, setBusy] = useState(false);
+
+  async function onConfirm() {
+    setBusy(true);
+    try {
+      await del.mutateAsync(docId);
+      toast.success("Document deleted", {
+        description: docLabel,
+      });
+      onOpenChange(false);
+      onDeleted?.();
+    } catch (e) {
+      const msg = (e as Error).message || "Unknown error";
+      toast.error("Delete failed", { description: msg });
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Delete this document?</DialogTitle>
+          <DialogDescription>
+            This permanently removes <span className="font-medium text-foreground">{docLabel}</span>{" "}
+            from this project, including its chunks, embeddings, and
+            any entities or claims that came only from it. This cannot
+            be undone.
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <DialogClose asChild>
+            <Button type="button" variant="outline" disabled={busy}>
+              Cancel
+            </Button>
+          </DialogClose>
+          <Button
+            type="button"
+            variant="destructive"
+            onClick={onConfirm}
+            disabled={busy}
+          >
+            {busy ? "Deleting…" : "Delete"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/ui/src/routes/documents/DocumentView.tsx
+++ b/ui/src/routes/documents/DocumentView.tsx
@@ -1,19 +1,24 @@
-import { useMemo } from "react";
-import { useParams } from "react-router-dom";
+import { useMemo, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import { Trash2 } from "lucide-react";
 import MarkdownIt from "markdown-it";
 import { useDoc, useDocChunks } from "@/hooks/api/useDocs";
 import { useProjectStore } from "@/stores/project";
 import { EmptyState, ErrorState, LoadingSkeleton } from "@/components/empty";
 import { useDocumentTitle } from "@/hooks/useDocumentTitle";
+import { Button } from "@/components/ui/button";
+import { DeleteDocumentDialog } from "./DeleteDocumentDialog";
 
 const md = new MarkdownIt({ html: false, linkify: true, breaks: false });
 
 export default function DocumentView() {
   const { id } = useParams();
+  const navigate = useNavigate();
   const project = useProjectStore((s) => s.slug);
   const { data, isLoading, error, refetch } = useDoc(project, id);
   const { data: chunks, isLoading: chunksLoading } = useDocChunks(project, id);
   const err = error as Error | null | undefined;
+  const [deleteOpen, setDeleteOpen] = useState(false);
 
   const docLabel = data?.title || data?.path;
   useDocumentTitle(docLabel ? [docLabel, "Documents"] : undefined);
@@ -61,13 +66,35 @@ export default function DocumentView() {
 
   return (
     <article className="doc-view p-8 max-w-[760px] mx-auto">
-      <header className="doc-view-header mb-6">
-        <h1 className="doc-view-title text-2xl font-semibold">{data.title || data.path}</h1>
-        <div className="doc-view-meta text-sm opacity-70 mt-1">
-          {data.doc_type} · v{data.version}
-          {orderedChunks.length > 0 && ` · ${orderedChunks.length} chunk${orderedChunks.length === 1 ? "" : "s"}`}
+      <header className="doc-view-header mb-6 flex items-start justify-between gap-4">
+        <div className="min-w-0">
+          <h1 className="doc-view-title text-2xl font-semibold">{data.title || data.path}</h1>
+          <div className="doc-view-meta text-sm opacity-70 mt-1">
+            {data.doc_type} · v{data.version}
+            {orderedChunks.length > 0 && ` · ${orderedChunks.length} chunk${orderedChunks.length === 1 ? "" : "s"}`}
+          </div>
         </div>
+        <Button
+          type="button"
+          variant="destructive"
+          size="sm"
+          onClick={() => setDeleteOpen(true)}
+          aria-label="Delete this document"
+        >
+          <Trash2 />
+          Delete
+        </Button>
       </header>
+      {data && id && (
+        <DeleteDocumentDialog
+          open={deleteOpen}
+          onOpenChange={setDeleteOpen}
+          project={project}
+          docId={id}
+          docLabel={data.title || data.path}
+          onDeleted={() => navigate("/docs")}
+        />
+      )}
 
       {chunksLoading ? (
         <LoadingSkeleton label="Loading content" rows={6} />

--- a/ui/src/routes/documents/DocumentsList.tsx
+++ b/ui/src/routes/documents/DocumentsList.tsx
@@ -1,11 +1,13 @@
 import { Link } from "react-router-dom";
 import { useState } from "react";
+import { Trash2 } from "lucide-react";
 import { useDocs } from "@/hooks/api/useDocs";
 import { useProjectStore } from "@/stores/project";
 import { formatRelativeTime } from "@/lib/format";
 import { Button } from "@/components/ui/button";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { UploadModal } from "./UploadModal";
+import { DeleteDocumentDialog } from "./DeleteDocumentDialog";
 import { EmptyState, ErrorState, LoadingSkeleton } from "@/components/empty";
 
 export default function DocumentsList() {
@@ -14,6 +16,10 @@ export default function DocumentsList() {
   const docs = data ?? [];
   const err = error as Error | null | undefined;
   const [uploadOpen, setUploadOpen] = useState(false);
+  // Single-shot delete target. We only ever confirm one document at a
+  // time; storing the id here keeps the dialog component pure and the
+  // table's per-row buttons simple.
+  const [pendingDelete, setPendingDelete] = useState<{ id: string; label: string } | null>(null);
 
   return (
     <div className="docs-page">
@@ -22,6 +28,17 @@ export default function DocumentsList() {
         <Button onClick={() => setUploadOpen(true)}>Upload</Button>
       </div>
       <UploadModal open={uploadOpen} onOpenChange={setUploadOpen} />
+      {pendingDelete && (
+        <DeleteDocumentDialog
+          open={!!pendingDelete}
+          onOpenChange={(next) => {
+            if (!next) setPendingDelete(null);
+          }}
+          project={project}
+          docId={pendingDelete.id}
+          docLabel={pendingDelete.label}
+        />
+      )}
       {isLoading ? (
         <LoadingSkeleton label="Loading documents" rows={6} />
       ) : err ? (
@@ -43,6 +60,7 @@ export default function DocumentsList() {
                 <TableHead>Title</TableHead>
                 <TableHead>Type</TableHead>
                 <TableHead>Updated</TableHead>
+                <TableHead className="w-12 text-right sr-only">Actions</TableHead>
               </TableRow>
             </TableHeader>
             <TableBody>
@@ -56,6 +74,18 @@ export default function DocumentsList() {
                   <TableCell className="text-muted-foreground">{d.doc_type}</TableCell>
                   <TableCell className="text-muted-foreground">
                     {formatRelativeTime(d.updated_at * 1000)}
+                  </TableCell>
+                  <TableCell className="text-right">
+                    <Button
+                      variant="ghost"
+                      size="icon-sm"
+                      aria-label={`Delete ${d.title || d.path}`}
+                      onClick={() =>
+                        setPendingDelete({ id: d.id, label: d.title || d.path })
+                      }
+                    >
+                      <Trash2 />
+                    </Button>
                   </TableCell>
                 </TableRow>
               ))}

--- a/ui/src/routes/documents/__tests__/DeleteDocumentDialog.test.tsx
+++ b/ui/src/routes/documents/__tests__/DeleteDocumentDialog.test.tsx
@@ -1,0 +1,126 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { server } from "@/test/msw";
+import { DeleteDocumentDialog } from "../DeleteDocumentDialog";
+
+// sonner has its own mounted Toaster portal in production. The unit
+// test asserts the toast call surface, not its DOM rendering — that
+// keeps the test fast (no portal, no animations) and the assertion
+// targeted on the contract we care about: success / failure feedback.
+const toastMock = {
+  success: vi.fn(),
+  error: vi.fn(),
+};
+vi.mock("sonner", () => ({
+  toast: {
+    success: (...args: unknown[]) => toastMock.success(...args),
+    error: (...args: unknown[]) => toastMock.error(...args),
+  },
+}));
+
+function Wrapper({ children }: { children: React.ReactNode }) {
+  // Fresh client per render so cache pollution can't leak between
+  // tests. retry: false so a network error fails fast instead of
+  // burning the test timeout on three retries.
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
+afterEach(() => {
+  toastMock.success.mockReset();
+  toastMock.error.mockReset();
+});
+
+describe("DeleteDocumentDialog", () => {
+  it("renders the document label and a Cancel + Delete button", () => {
+    render(
+      <Wrapper>
+        <DeleteDocumentDialog
+          open
+          onOpenChange={() => {}}
+          project="_default"
+          docId="d1"
+          docLabel="my-doc.md"
+        />
+      </Wrapper>,
+    );
+    expect(screen.getByRole("heading", { name: /delete this document/i })).toBeInTheDocument();
+    expect(screen.getByText("my-doc.md")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /^cancel$/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /^delete$/i })).toBeInTheDocument();
+  });
+
+  it("calls DELETE and surfaces a success toast on confirm", async () => {
+    const seen: string[] = [];
+    server.use(
+      http.delete("/api/documents/:id", ({ request, params }) => {
+        seen.push(`${request.method} ${params.id as string}`);
+        return new HttpResponse(null, { status: 204 });
+      }),
+    );
+
+    const onOpenChange = vi.fn();
+    const onDeleted = vi.fn();
+    render(
+      <Wrapper>
+        <DeleteDocumentDialog
+          open
+          onOpenChange={onOpenChange}
+          project="_default"
+          docId="d1"
+          docLabel="my-doc.md"
+          onDeleted={onDeleted}
+        />
+      </Wrapper>,
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: /^delete$/i }));
+
+    await vi.waitFor(() => {
+      expect(seen).toEqual(["DELETE d1"]);
+    });
+    await vi.waitFor(() => {
+      expect(toastMock.success).toHaveBeenCalledTimes(1);
+      expect(onOpenChange).toHaveBeenCalledWith(false);
+      expect(onDeleted).toHaveBeenCalledTimes(1);
+    });
+    expect(toastMock.error).not.toHaveBeenCalled();
+  });
+
+  it("surfaces an error toast and keeps the dialog open on server failure", async () => {
+    server.use(
+      http.delete("/api/documents/:id", () =>
+        HttpResponse.json({ error: "boom" }, { status: 500 }),
+      ),
+    );
+
+    const onOpenChange = vi.fn();
+    const onDeleted = vi.fn();
+    render(
+      <Wrapper>
+        <DeleteDocumentDialog
+          open
+          onOpenChange={onOpenChange}
+          project="_default"
+          docId="d1"
+          docLabel="my-doc.md"
+          onDeleted={onDeleted}
+        />
+      </Wrapper>,
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: /^delete$/i }));
+
+    await vi.waitFor(() => {
+      expect(toastMock.error).toHaveBeenCalledTimes(1);
+    });
+    expect(onDeleted).not.toHaveBeenCalled();
+    // Dialog should remain open on error so the user can retry.
+    expect(onOpenChange).not.toHaveBeenCalledWith(false);
+  });
+});


### PR DESCRIPTION
## Summary

Today there is no way to remove a document once it has been uploaded. Users hit the `documents.file_hash UNIQUE` collision when they try to reindex (the supersede path bumps `version` but never frees the row), and a bad upload leaves orphan entities, relationships, claims, chunks, and embeddings in the knowledge graph forever.

This PR adds an authenticated `DELETE /api/documents/{id}` plus a per-row icon button on the documents list and a destructive button on the document detail page. The cascade runs in a single SQLite transaction and is idempotent: redeleting the same id is a 404, not a second 204.

**Cascade order (single tx):**
1. `relationships` WHERE `doc_id = ?` — drop edges sourced from this doc
2. `claims` WHERE `doc_id = ?` — drop claims sourced from this doc
3. `chunks` WHERE `doc_id = ?` — embeddings cascade via FK
4. `documents` WHERE `id = ?` — the row itself
5. Orphan-entity sweep — entities with no remaining relationship or claim reference are dropped; `community_members` rows cascade via FK

**Tradeoff:** communities are deliberately NOT recomputed inline. Louvain on a meaningfully sized graph is too slow for an interactive DELETE; stale community titles/summaries are tolerable until the next manual `community.finalize`. Documented in both the handler and the store-layer comments.

The per-project HNSW index is invalidated so the next vector search rebuilds against the post-delete chunk set.

## Files changed

**Backend (Go)**
- `internal/api/router.go` — register `DELETE /api/documents/{id}` in the existing bearer-auth chain
- `internal/api/handlers.go` — new `deleteDocument` handler (204 / 404 / 500)
- `internal/store/store.go` — rewrite `Store.DeleteDocument` with the transactional cascade + orphan sweep
- `internal/api/document_delete_test.go` — handler table tests + store-layer cascade test

**Frontend (TS/React)**
- `ui/src/hooks/api/useDocs.ts` — `useDeleteDoc` mutation, invalidates `docs`, `stats`, `entityGraph`
- `ui/src/routes/documents/DeleteDocumentDialog.tsx` — shared confirm dialog with destructive button + sonner toast
- `ui/src/routes/documents/DocumentsList.tsx` — per-row `Trash2` ghost icon button
- `ui/src/routes/documents/DocumentView.tsx` — destructive header button, navigates to `/docs` on success
- `ui/src/components/layout/Providers.tsx` — mount the `<Toaster />` portal (was unmounted; no toasts existed in the codebase yet)
- `ui/src/routes/documents/__tests__/DeleteDocumentDialog.test.tsx` — Vitest + MSW unit test (render, success, server-error)

## Test plan

- [x] `make check` clean (Go build + vet + test, UI build + vitest run): 31 UI test files / 105 tests pass; Go suite green
- [x] New handler tests: 404 on unknown id, 204 on happy path with full graph-state assertions (chunks/embeddings/claims/orphan-entities removed; shared entities preserved), idempotency (second DELETE → 404)
- [x] New store-layer cascade test confirms transaction touches all five tables
- [x] New Vitest test asserts: dialog renders label + Cancel/Delete; confirm calls `DELETE /api/documents/:id` and fires success toast + `onDeleted` callback; server 500 surfaces error toast and dialog stays open
- [x] E2E smoke against built `./docsiq` binary: seeded a doc with 2 entities + 1 relationship + 1 claim, `DELETE /api/documents/{id}` returned **204** with empty body, `GET /api/documents` returned `null`, `GET /api/graph` returned `{edges:[], nodes:[]}`, `GET /api/entities` returned `null` (orphan sweep landed). Second DELETE returned **404**. Unauthenticated DELETE returned **401**.

## Out of scope

- No community recomputation (left stale until next finalize — documented).
- No soft-delete / restore (hard delete only).
- No FTS5 or sqlite-vec extension changes.
- No release tag (parent thread handles that).

🤖 Generated with [Claude Code](https://claude.com/claude-code)